### PR TITLE
Draft-10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,12 @@
 Version history
 ===============
 
+### 0.10.0 (2014-03-10) ###
+
+* Upgrade to the latest draft: [draft-ietf-httpbis-http2-10][draft-10]
+
+[draft-10]: http://tools.ietf.org/html/draft-ietf-httpbis-http2-10
+
 ### 0.9.1 (2014-01-11) ###
 
 * Updated the examples (#5)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 node-http2-protocol
 ===================
 
-An HTTP/2 ([draft-ietf-httpbis-http2-09](http://tools.ietf.org/html/draft-ietf-httpbis-http2-09))
+An HTTP/2 ([draft-ietf-httpbis-http2-10](http://tools.ietf.org/html/draft-ietf-httpbis-http2-10))
 framing layer implementaion for node.js.
 
 Installation

--- a/example/client.js
+++ b/example/client.js
@@ -5,7 +5,7 @@ var http2 = require('..');
 var tls = require('tls');
 
 // Advertised protocol version
-var implementedVersion = 'HTTP-draft-09/2.0';
+var implementedVersion = http2.ImplementedVersion;
 
 // Bunyan logger
 var log = require('../test/util').createLogger('client');

--- a/example/server.js
+++ b/example/server.js
@@ -9,7 +9,7 @@ var read = fs.createReadStream;
 var join = path.join;
 
 // Advertised protocol version
-var implementedVersion = 'HTTP-draft-09/2.0';
+var implementedVersion = http2.ImplementedVersion;
 
 // Bunyan logger
 var log = require('../test/util').createLogger('server');

--- a/lib/compressor.js
+++ b/lib/compressor.js
@@ -228,12 +228,11 @@ HeaderTable.staticTable  = [
 // until the end os the stream, and then processes the whole header block at once.
 
 util.inherits(HeaderSetDecompressor, TransformStream);
-function HeaderSetDecompressor(log, table, huffmanTable) {
+function HeaderSetDecompressor(log, table) {
   TransformStream.call(this, { objectMode: true });
 
   this._log = log.child({ component: 'compressor' });
   this._table = table;
-  this._huffmanTable = huffmanTable;
   this._chunks = [];
 }
 
@@ -275,7 +274,8 @@ HeaderSetDecompressor.prototype._execute = function _execute(rep) {
 
   // * An _indexed representation_ with an index value of 0 (in our representation, it means -1)
   //   entails the following actions:
-  //   * The reference set is emptied.
+  //   * If the following byte starts with a set bit, the reference set is emptied.
+  //   * Else, reduce the size of the header table to the value encoded with a 7-bit prefix
   // * An _indexed representation_ corresponding to an entry _present_ in the reference set
   //   entails the following actions:
   //   * The entry is removed from the reference set.
@@ -294,8 +294,13 @@ HeaderSetDecompressor.prototype._execute = function _execute(rep) {
     entry = this._table[index];
 
     if (index == -1) {
-      for (var i = 0; i < this._table.length; i++) {
-        this._table[i].reference = false;
+      if (rep.index) {
+        for (var i = 0; i < this._table.length; i++) {
+          this._table[i].reference = false;
+        }
+      } else {
+        // Set a new maximum size
+        this.setTableSizeLimit(rep.name);
       }
     }
 
@@ -352,7 +357,7 @@ HeaderSetDecompressor.prototype._flush = function _flush(callback) {
   // * processes the header representations
   buffer.cursor = 0;
   while (buffer.cursor < buffer.length) {
-    this._execute(HeaderSetDecompressor.header(buffer, this._huffmanTable));
+    this._execute(HeaderSetDecompressor.header(buffer));
   }
 
   // * [emits the reference set](http://tools.ietf.org/html/draft-ietf-httpbis-header-compression-05#section-3.2.2)
@@ -380,12 +385,11 @@ HeaderSetDecompressor.prototype._flush = function _flush(callback) {
 // compression algorithm can probably be improved in the future.
 
 util.inherits(HeaderSetCompressor, TransformStream);
-function HeaderSetCompressor(log, table, huffmanTable) {
+function HeaderSetCompressor(log, table) {
   TransformStream.call(this, { objectMode: true });
 
   this._log = log.child({ component: 'compressor' });
   this._table = table;
-  this._huffmanTable = huffmanTable;
   this.push = TransformStream.prototype.push.bind(this);
 }
 
@@ -394,7 +398,7 @@ HeaderSetCompressor.prototype.send = function send(rep) {
                   'Emitting header representation');
 
   if (!rep.chunks) {
-    rep.chunks = HeaderSetCompressor.header(rep, this._huffmanTable);
+    rep.chunks = HeaderSetCompressor.header(rep);
   }
   rep.chunks.forEach(this.push);
 };
@@ -705,7 +709,7 @@ HuffmanTable.prototype.decode = function decode(buffer) {
 //
 //     sed -e "s/^.* [|]//g" -e "s/|//g" -e "s/ .*//g" -e "s/^/  '/g" -e "s/$/',/g"
 
-HuffmanTable.requestHuffmanTable = new HuffmanTable([
+HuffmanTable.huffmanTable = new HuffmanTable([
   '111111111111111111110111010',
   '111111111111111111110111011',
   '111111111111111111110111100',
@@ -965,266 +969,6 @@ HuffmanTable.requestHuffmanTable = new HuffmanTable([
   '11111111111111111111011100'
 ]);
 
-HuffmanTable.responseHuffmanTable = new HuffmanTable([
-  '1111111111111111110111100',
-  '1111111111111111110111101',
-  '1111111111111111110111110',
-  '1111111111111111110111111',
-  '1111111111111111111000000',
-  '1111111111111111111000001',
-  '1111111111111111111000010',
-  '1111111111111111111000011',
-  '1111111111111111111000100',
-  '1111111111111111111000101',
-  '1111111111111111111000110',
-  '1111111111111111111000111',
-  '1111111111111111111001000',
-  '1111111111111111111001001',
-  '1111111111111111111001010',
-  '1111111111111111111001011',
-  '1111111111111111111001100',
-  '1111111111111111111001101',
-  '1111111111111111111001110',
-  '1111111111111111111001111',
-  '1111111111111111111010000',
-  '1111111111111111111010001',
-  '1111111111111111111010010',
-  '1111111111111111111010011',
-  '1111111111111111111010100',
-  '1111111111111111111010101',
-  '1111111111111111111010110',
-  '1111111111111111111010111',
-  '1111111111111111111011000',
-  '1111111111111111111011001',
-  '1111111111111111111011010',
-  '1111111111111111111011011',
-  '0000',
-  '111111111010',
-  '1101010',
-  '1111111111010',
-  '11111111111100',
-  '111101100',
-  '1111111000',
-  '1111111111011',
-  '111101101',
-  '111101110',
-  '111111111011',
-  '11111111010',
-  '100010',
-  '100011',
-  '100100',
-  '1101011',
-  '0001',
-  '0010',
-  '0011',
-  '01000',
-  '01001',
-  '01010',
-  '100101',
-  '100110',
-  '01011',
-  '01100',
-  '01101',
-  '111101111',
-  '1111111111111010',
-  '1101100',
-  '1111111111100',
-  '111111111100',
-  '1111111111111011',
-  '1101101',
-  '11101010',
-  '11101011',
-  '11101100',
-  '11101101',
-  '11101110',
-  '100111',
-  '111110000',
-  '11101111',
-  '11110000',
-  '1111111001',
-  '111110001',
-  '101000',
-  '11110001',
-  '11110010',
-  '111110010',
-  '1111111010',
-  '111110011',
-  '101001',
-  '01110',
-  '111110100',
-  '111110101',
-  '11110011',
-  '1111111011',
-  '111110110',
-  '1111111100',
-  '11111111011',
-  '1111111111101',
-  '11111111100',
-  '111111111111100',
-  '111110111',
-  '11111111111111110',
-  '01111',
-  '1101110',
-  '101010',
-  '101011',
-  '10000',
-  '1101111',
-  '1110000',
-  '1110001',
-  '101100',
-  '111111000',
-  '111111001',
-  '1110010',
-  '101101',
-  '101110',
-  '101111',
-  '110000',
-  '111111010',
-  '110001',
-  '110010',
-  '110011',
-  '110100',
-  '1110011',
-  '11110100',
-  '1110100',
-  '11110101',
-  '111111011',
-  '1111111111111100',
-  '11111111111101',
-  '1111111111111101',
-  '1111111111111110',
-  '1111111111111111111011100',
-  '1111111111111111111011101',
-  '1111111111111111111011110',
-  '1111111111111111111011111',
-  '1111111111111111111100000',
-  '1111111111111111111100001',
-  '1111111111111111111100010',
-  '1111111111111111111100011',
-  '1111111111111111111100100',
-  '1111111111111111111100101',
-  '1111111111111111111100110',
-  '1111111111111111111100111',
-  '1111111111111111111101000',
-  '1111111111111111111101001',
-  '1111111111111111111101010',
-  '1111111111111111111101011',
-  '1111111111111111111101100',
-  '1111111111111111111101101',
-  '1111111111111111111101110',
-  '1111111111111111111101111',
-  '1111111111111111111110000',
-  '1111111111111111111110001',
-  '1111111111111111111110010',
-  '1111111111111111111110011',
-  '1111111111111111111110100',
-  '1111111111111111111110101',
-  '1111111111111111111110110',
-  '1111111111111111111110111',
-  '1111111111111111111111000',
-  '1111111111111111111111001',
-  '1111111111111111111111010',
-  '1111111111111111111111011',
-  '1111111111111111111111100',
-  '1111111111111111111111101',
-  '1111111111111111111111110',
-  '1111111111111111111111111',
-  '111111111111111110000000',
-  '111111111111111110000001',
-  '111111111111111110000010',
-  '111111111111111110000011',
-  '111111111111111110000100',
-  '111111111111111110000101',
-  '111111111111111110000110',
-  '111111111111111110000111',
-  '111111111111111110001000',
-  '111111111111111110001001',
-  '111111111111111110001010',
-  '111111111111111110001011',
-  '111111111111111110001100',
-  '111111111111111110001101',
-  '111111111111111110001110',
-  '111111111111111110001111',
-  '111111111111111110010000',
-  '111111111111111110010001',
-  '111111111111111110010010',
-  '111111111111111110010011',
-  '111111111111111110010100',
-  '111111111111111110010101',
-  '111111111111111110010110',
-  '111111111111111110010111',
-  '111111111111111110011000',
-  '111111111111111110011001',
-  '111111111111111110011010',
-  '111111111111111110011011',
-  '111111111111111110011100',
-  '111111111111111110011101',
-  '111111111111111110011110',
-  '111111111111111110011111',
-  '111111111111111110100000',
-  '111111111111111110100001',
-  '111111111111111110100010',
-  '111111111111111110100011',
-  '111111111111111110100100',
-  '111111111111111110100101',
-  '111111111111111110100110',
-  '111111111111111110100111',
-  '111111111111111110101000',
-  '111111111111111110101001',
-  '111111111111111110101010',
-  '111111111111111110101011',
-  '111111111111111110101100',
-  '111111111111111110101101',
-  '111111111111111110101110',
-  '111111111111111110101111',
-  '111111111111111110110000',
-  '111111111111111110110001',
-  '111111111111111110110010',
-  '111111111111111110110011',
-  '111111111111111110110100',
-  '111111111111111110110101',
-  '111111111111111110110110',
-  '111111111111111110110111',
-  '111111111111111110111000',
-  '111111111111111110111001',
-  '111111111111111110111010',
-  '111111111111111110111011',
-  '111111111111111110111100',
-  '111111111111111110111101',
-  '111111111111111110111110',
-  '111111111111111110111111',
-  '111111111111111111000000',
-  '111111111111111111000001',
-  '111111111111111111000010',
-  '111111111111111111000011',
-  '111111111111111111000100',
-  '111111111111111111000101',
-  '111111111111111111000110',
-  '111111111111111111000111',
-  '111111111111111111001000',
-  '111111111111111111001001',
-  '111111111111111111001010',
-  '111111111111111111001011',
-  '111111111111111111001100',
-  '111111111111111111001101',
-  '111111111111111111001110',
-  '111111111111111111001111',
-  '111111111111111111010000',
-  '111111111111111111010001',
-  '111111111111111111010010',
-  '111111111111111111010011',
-  '111111111111111111010100',
-  '111111111111111111010101',
-  '111111111111111111010110',
-  '111111111111111111010111',
-  '111111111111111111011000',
-  '111111111111111111011001',
-  '111111111111111111011010',
-  '111111111111111111011011',
-  '111111111111111111011100',
-  '111111111111111111011101'
-]);
-
 // ### String literal representation ###
 //
 // Literal **strings** can represent header names or header values. There's two variant of the
@@ -1256,10 +1000,10 @@ HuffmanTable.responseHuffmanTable = new HuffmanTable([
 //     |  Field Bytes Without Encoding |
 //     +---+---+---+---+---+---+---+---+
 
-HeaderSetCompressor.string = function writeString(str, huffmanTable) {
+HeaderSetCompressor.string = function writeString(str) {
   str = new Buffer(str, 'utf8');
 
-  var huffman = huffmanTable.encode(str);
+  var huffman = HuffmanTable.huffmanTable.encode(str);
   if (huffman.length < str.length) {
     var length = HeaderSetCompressor.integer(huffman.length, 7)
     length[0][0] |= 128;
@@ -1272,12 +1016,12 @@ HeaderSetCompressor.string = function writeString(str, huffmanTable) {
   }
 };
 
-HeaderSetDecompressor.string = function readString(buffer, huffmanTable) {
+HeaderSetDecompressor.string = function readString(buffer) {
   var huffman = buffer[buffer.cursor] & 128;
   var length = HeaderSetDecompressor.integer(buffer, 7);
   var encoded = buffer.slice(buffer.cursor, buffer.cursor + length);
   buffer.cursor += length;
-  return (huffman ? huffmanTable.decode(encoded) : encoded).toString('utf8');
+  return (huffman ? HuffmanTable.huffmanTable.decode(encoded) : encoded).toString('utf8');
 };
 
 // ### Header represenations ###
@@ -1353,7 +1097,7 @@ var representations = {
   literalIncremental  : { prefix: 6, pattern: 0x00 }
 };
 
-HeaderSetCompressor.header = function writeHeader(header, huffmanTable) {
+HeaderSetCompressor.header = function writeHeader(header) {
   var representation, buffers = [];
 
   if (typeof header.value === 'number') {
@@ -1366,6 +1110,13 @@ HeaderSetCompressor.header = function writeHeader(header, huffmanTable) {
 
   if (representation === representations.indexed) {
     buffers.push(HeaderSetCompressor.integer(header.value + 1, representation.prefix));
+    if (header.value == -1) {
+      if (header.index) {
+        buffers.push(HeaderSetCompressor.integer(0x80, 8));
+      } else {
+        buffers.push(HeaderSetCompressor.integer(header.name, 7));
+      }
+    }
   }
 
   else {
@@ -1373,9 +1124,9 @@ HeaderSetCompressor.header = function writeHeader(header, huffmanTable) {
       buffers.push(HeaderSetCompressor.integer(header.name + 1, representation.prefix));
     } else {
       buffers.push(HeaderSetCompressor.integer(0, representation.prefix));
-      buffers.push(HeaderSetCompressor.string(header.name, huffmanTable));
+      buffers.push(HeaderSetCompressor.string(header.name));
     }
-    buffers.push(HeaderSetCompressor.string(header.value, huffmanTable));
+    buffers.push(HeaderSetCompressor.string(header.value));
   }
 
   buffers[0][0][0] |= representation.pattern;
@@ -1383,7 +1134,7 @@ HeaderSetCompressor.header = function writeHeader(header, huffmanTable) {
   return Array.prototype.concat.apply([], buffers); // array of arrays of buffers -> array of buffers
 };
 
-HeaderSetDecompressor.header = function readHeader(buffer, huffmanTable) {
+HeaderSetDecompressor.header = function readHeader(buffer) {
   var representation, header = {};
 
   var firstByte = buffer[buffer.cursor];
@@ -1398,14 +1149,22 @@ HeaderSetDecompressor.header = function readHeader(buffer, huffmanTable) {
   if (representation === representations.indexed) {
     header.value = header.name = HeaderSetDecompressor.integer(buffer, representation.prefix) - 1;
     header.index = false;
+    if (header.value === -1) {
+      if (buffer[buffer.cursor] & 0x80) {
+        header.index = true;
+        buffer.cursor += 1;
+      } else {
+        header.name = HeaderSetDecompressor.integer(buffer, 7);
+      }
+    }
   }
 
   else {
     header.name = HeaderSetDecompressor.integer(buffer, representation.prefix) - 1;
     if (header.name === -1) {
-      header.name = HeaderSetDecompressor.string(buffer, huffmanTable);
+      header.name = HeaderSetDecompressor.string(buffer);
     }
-    header.value = HeaderSetDecompressor.string(buffer, huffmanTable);
+    header.value = HeaderSetDecompressor.string(buffer);
     header.index = (representation === representations.literalIncremental);
   }
 
@@ -1447,8 +1206,6 @@ function Compressor(log, type) {
   this._log = log.child({ component: 'compressor' });
 
   assert((type === 'REQUEST') || (type === 'RESPONSE'));
-  this._huffmanTable = (type === 'REQUEST') ? HuffmanTable.requestHuffmanTable
-                                            : HuffmanTable.responseHuffmanTable;
   this._table = new HeaderTable(this._log);
 }
 
@@ -1461,7 +1218,7 @@ Compressor.prototype.setTableSizeLimit = function setTableSizeLimit(size) {
 // instance. This means that from now on, the advantages of streaming header encoding are lost,
 // but the API becomes simpler.
 Compressor.prototype.compress = function compress(headers) {
-  var compressor = new HeaderSetCompressor(this._log, this._table, this._huffmanTable);
+  var compressor = new HeaderSetCompressor(this._log, this._table);
   for (var name in headers) {
     var value = headers[name];
     name = String(name).toLowerCase();
@@ -1564,8 +1321,6 @@ function Decompressor(log, type) {
   this._log = log.child({ component: 'compressor' });
 
   assert((type === 'REQUEST') || (type === 'RESPONSE'));
-  this._huffmanTable = (type === 'REQUEST') ? HuffmanTable.requestHuffmanTable
-                                            : HuffmanTable.responseHuffmanTable;
   this._table = new HeaderTable(this._log);
 
   this._inProgress = false;
@@ -1581,7 +1336,7 @@ Decompressor.prototype.setTableSizeLimit = function setTableSizeLimit(size) {
 // stream instance. This means that from now on, the advantages of streaming header decoding are
 // lost, but the API becomes simpler.
 Decompressor.prototype.decompress = function decompress(block) {
-  var decompressor = new HeaderSetDecompressor(this._log, this._table, this._huffmanTable);
+  var decompressor = new HeaderSetDecompressor(this._log, this._table);
   decompressor.end(block);
 
   var headers = {};

--- a/lib/framer.js
+++ b/lib/framer.js
@@ -66,7 +66,8 @@ Serializer.prototype._transform = function _transform(frame, encoding, done) {
 //     empty      adds parsed              adds parsed
 //     object  header properties        payload properties
 
-function Deserializer(log, sizeLimit) {
+function Deserializer(log, sizeLimit, role) {
+  this._role = role;
   this._log = log.child({ component: 'deserializer' });
   this._sizeLimit = sizeLimit || MAX_PAYLOAD_SIZE;
   Transform.call(this, { objectMode: true });
@@ -127,7 +128,7 @@ Deserializer.prototype._transform = function _transform(chunk, encoding, done) {
     // will also run.
     if ((this._cursor === this._buffer.length) && !this._waitingForHeader) {
       if (this._frame.type) {
-        var error = Deserializer[this._frame.type](this._buffer, this._frame);
+        var error = Deserializer[this._frame.type](this._buffer, this._frame, this._role);
         if (error) {
           this._log.error('Incoming frame parsing error: ' + error);
           this.emit('error', 'PROTOCOL_ERROR');
@@ -136,7 +137,8 @@ Deserializer.prototype._transform = function _transform(chunk, encoding, done) {
           this.push(this._frame);
         }
       } else {
-        this._log.warn({ frame: this._frame }, 'Unknown type incoming frame');
+        this._log.error('Unknown type incoming frame');
+        this.emit('error', 'PROTOCOL_ERROR');
       }
       this._next(COMMON_HEADER_SIZE);
     }
@@ -145,7 +147,7 @@ Deserializer.prototype._transform = function _transform(chunk, encoding, done) {
   done();
 };
 
-// [Frame Header](http://tools.ietf.org/html/draft-ietf-httpbis-http2-09#section-4.1)
+// [Frame Header](http://tools.ietf.org/html/draft-ietf-httpbis-http2-10#section-4.1)
 // --------------------------------------------------------------
 //
 // HTTP/2.0 frames share a common base format consisting of an 8-byte header followed by 0 to 65535
@@ -259,7 +261,7 @@ Deserializer.commonHeader = function readCommonHeader(buffer, frame) {
 // * `typeSpecificAttributes`: a register of frame specific frame object attributes (used by
 //   logging code and also serves as documentation for frame objects)
 
-// [DATA Frames](http://tools.ietf.org/html/draft-ietf-httpbis-http2-09#section-6.1)
+// [DATA Frames](http://tools.ietf.org/html/draft-ietf-httpbis-http2-10#section-6.1)
 // ------------------------------------------------------------
 //
 // DATA frames (type=0x0) convey arbitrary, variable-length sequences of octets associated with a
@@ -270,12 +272,20 @@ Deserializer.commonHeader = function readCommonHeader(buffer, frame) {
 // * END_STREAM (0x1):
 //   Bit 1 being set indicates that this frame is the last that the endpoint will send for the
 //   identified stream.
-// * RESERVED (0x2):
-//   Bit 2 is reserved for future use.
+// * END_SEGMENT (0x2):
+//   Bit 2 being set indicates that this frame is the last for the current segment. Intermediaries
+//   MUST NOT coalesce frames across a segment boundary and MUST preserve segment boundaries when
+//   forwarding frames.
+// * PAD_LOW (0x10):
+//   Bit 5 being set indicates that the Pad Low field is present.
+// * PAD_HIGH (0x20):
+//   Bit 6 being set indicates that the Pad High field is present. This bit MUST NOT be set unless
+//   the PAD_LOW flag is also set. Endpoints that receive a frame with PAD_HIGH set and PAD_LOW
+//   cleared MUST treat this as a connection error of type PROTOCOL_ERROR.
 
 frameTypes[0x0] = 'DATA';
 
-frameFlags.DATA = ['END_STREAM', 'RESERVED'];
+frameFlags.DATA = ['END_STREAM', 'END_SEGMENT', 'RESERVED4', 'RESERVED8', 'PAD_LOW', 'PAD_HIGH'];
 
 typeSpecificAttributes.DATA = ['data'];
 
@@ -284,10 +294,26 @@ Serializer.DATA = function writeData(frame, buffers) {
 };
 
 Deserializer.DATA = function readData(buffer, frame) {
-  frame.data = buffer;
+  var dataOffset = 0;
+  var paddingLength = 0;
+  if (frame.flags.PAD_LOW) {
+    if (frame.flags.PAD_HIGH) {
+      paddingLength = (buffer.readUInt8(dataOffset) & 0xff) * 256;
+      dataOffset += 1;
+    }
+    paddingLength += (buffer.readUInt8(dataOffset) & 0xff);
+    dataOffset += 1;
+  } else if (frame.flags.PAD_HIGH) {
+    return 'DATA frame got PAD_HIGH without PAD_LOW';
+  }
+  if (paddingLength) {
+    frame.data = buffer.slice(dataOffset, -1 * paddingLength);
+  } else {
+    frame.data = buffer.slice(dataOffset);
+  }
 };
 
-// [HEADERS](http://tools.ietf.org/html/draft-ietf-httpbis-http2-09#section-6.2)
+// [HEADERS](http://tools.ietf.org/html/draft-ietf-httpbis-http2-10#section-6.2)
 // --------------------------------------------------------------
 //
 // The HEADERS frame (type=0x1) allows the sender to create a stream.
@@ -297,18 +323,26 @@ Deserializer.DATA = function readData(buffer, frame) {
 // * END_STREAM (0x1):
 //   Bit 1 being set indicates that this frame is the last that the endpoint will send for the
 //   identified stream.
-// * RESERVED (0x2):
-//   Bit 2 is reserved for future use.
+// * END_SEGMENT (0x2):
+//   Bit 2 being set indicates that this frame is the last for the current segment. Intermediaries
+//   MUST NOT coalesce frames across a segment boundary and MUST preserve segment boundaries when
+//   forwarding frames.
 // * END_HEADERS (0x4):
 //   The END_HEADERS bit indicates that this frame contains the entire payload necessary to provide
 //   a complete set of headers.
 // * PRIORITY (0x8):
 //   Bit 4 being set indicates that the first four octets of this frame contain a single reserved
 //   bit and a 31-bit priority.
+// * PAD_LOW (0x10):
+//   Bit 5 being set indicates that the Pad Low field is present.
+// * PAD_HIGH (0x20):
+//   Bit 6 being set indicates that the Pad High field is present. This bit MUST NOT be set unless
+//   the PAD_LOW flag is also set. Endpoints that receive a frame with PAD_HIGH set and PAD_LOW
+//   cleared MUST treat this as a connection error of type PROTOCOL_ERROR.
 
 frameTypes[0x1] = 'HEADERS';
 
-frameFlags.HEADERS = ['END_STREAM', 'RESERVED', 'END_HEADERS', 'PRIORITY'];
+frameFlags.HEADERS = ['END_STREAM', 'END_SEGMENT', 'END_HEADERS', 'PRIORITY', 'PAD_LOW', 'PAD_HIGH'];
 
 typeSpecificAttributes.HEADERS = ['priority', 'headers', 'data'];
 
@@ -333,15 +367,30 @@ Serializer.HEADERS = function writeHeadersPriority(frame, buffers) {
 };
 
 Deserializer.HEADERS = function readHeadersPriority(buffer, frame) {
+  var dataOffset = 0;
+  var paddingLength = 0;
+  if (frame.flags.PAD_LOW) {
+    if (frame.flags.PAD_HIGH) {
+      paddingLength = (buffer.readUInt8(dataOffset) & 0xff) * 256;
+      dataOffset += 1;
+    }
+    paddingLength += (buffer.readUInt8(dataOffset) & 0xff);
+    dataOffset += 1;
+  } else if (frame.flags.PAD_HIGH) {
+    return 'HEADERS frame got PAD_HIGH without PAD_LOW';
+  }
   if (frame.flags.PRIORITY) {
-    frame.priority = buffer.readUInt32BE(0) & 0x7fffffff;
-    frame.data = buffer.slice(4);
+    frame.priority = buffer.readUInt32BE(dataOffset) & 0x7fffffff;
+    dataOffset += 4;
+  }
+  if (paddingLength) {
+    frame.data = buffer.slice(dataOffset, -1 * paddingLength);
   } else {
-    frame.data = buffer;
+    frame.data = buffer.slice(dataOffset);
   }
 };
 
-// [PRIORITY](http://tools.ietf.org/html/draft-ietf-httpbis-http2-09#section-6.3)
+// [PRIORITY](http://tools.ietf.org/html/draft-ietf-httpbis-http2-10#section-6.3)
 // -------------------------------------------------------
 //
 // The PRIORITY frame (type=0x2) specifies the sender-advised priority of a stream.
@@ -372,7 +421,7 @@ Deserializer.PRIORITY = function readPriority(buffer, frame) {
   frame.priority = buffer.readUInt32BE(0);
 };
 
-// [RST_STREAM](http://tools.ietf.org/html/draft-ietf-httpbis-http2-09#section-6.4)
+// [RST_STREAM](http://tools.ietf.org/html/draft-ietf-httpbis-http2-10#section-6.4)
 // -----------------------------------------------------------
 //
 // The RST_STREAM frame (type=0x3) allows for abnormal termination of a stream.
@@ -406,7 +455,7 @@ Deserializer.RST_STREAM = function readRstStream(buffer, frame) {
   frame.error = errorCodes[buffer.readUInt32BE(0)];
 };
 
-// [SETTINGS](http://tools.ietf.org/html/draft-ietf-httpbis-http2-09#section-6.5)
+// [SETTINGS](http://tools.ietf.org/html/draft-ietf-httpbis-http2-10#section-6.5)
 // -------------------------------------------------------
 //
 // The SETTINGS frame (type=0x4) conveys configuration parameters that affect how endpoints
@@ -424,15 +473,15 @@ frameFlags.SETTINGS = ['ACK'];
 typeSpecificAttributes.SETTINGS = ['settings'];
 
 // The payload of a SETTINGS frame consists of zero or more settings. Each setting consists of an
-// 8-bit reserved field, an unsigned 24-bit setting identifier, and an unsigned 32-bit value.
+// 8-bit identifier, and an unsigned 32-bit value.
 //
 //      0                   1                   2                   3
 //      0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
 //     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-//     |  Reserved(8)  |             Setting Identifier (24)           |
-//     +---------------+-----------------------------------------------+
-//     |                        Value (32)                             |
-//     +---------------------------------------------------------------+
+//     |  Identifier(8)  |                  Value (32)                 |
+//     +-----------------+---------------------------------------------+
+//     ...Value          |
+//     +-----------------+
 //
 // Each setting in a SETTINGS frame replaces the existing value for that setting.  Settings are
 // processed in the order in which they appear, and a receiver of a SETTINGS frame does not need to
@@ -452,29 +501,33 @@ Serializer.SETTINGS = function writeSettings(frame, buffers) {
   });
   assert(settingsLeft.length === 0, 'Unknown settings: ' + settingsLeft.join(', '));
 
-  var buffer = new Buffer(settings.length * 8);
+  var buffer = new Buffer(settings.length * 5);
   for (var i = 0; i < settings.length; i++) {
-    buffer.writeUInt32BE(settings[i].id & 0xffffff, i*8);
-    buffer.writeUInt32BE(settings[i].value, i*8 + 4);
+    buffer.writeUInt8(settings[i].id & 0xff, i*5);
+    buffer.writeUInt32BE(settings[i].value, i*5 + 1);
   }
 
   buffers.push(buffer);
 };
 
-Deserializer.SETTINGS = function readSettings(buffer, frame) {
+Deserializer.SETTINGS = function readSettings(buffer, frame, role) {
   frame.settings = {};
 
-  if (buffer.length % 8 !== 0) {
+  if (buffer.length % 5 !== 0) {
     return 'Invalid SETTINGS frame';
   }
-  for (var i = 0; i < buffer.length / 8; i++) {
-    var id = buffer.readUInt32BE(i*8) & 0xffffff;
+  for (var i = 0; i < buffer.length / 5; i++) {
+    var id = buffer.readUInt8(i*5) & 0xff;
     var setting = definedSettings[id];
     if (setting) {
-      var value = buffer.readUInt32BE(i*8 + 4);
+      if (role == 'CLIENT' && setting.name == 'SETTINGS_ENABLE_PUSH') {
+        return 'SETTINGS frame on client got SETTINGS_ENABLE_PUSH';
+      }
+      var value = buffer.readUInt32BE(i*5 + 1);
       frame.settings[setting.name] = setting.flag ? Boolean(value & 0x1) : value;
     } else {
-      /* Unknown setting, ignoring */
+      /* Unknown setting, protocol error */
+      return 'SETTINGS frame got unknown setting type';
     }
   }
 };
@@ -495,19 +548,13 @@ definedSettings[2] = { name: 'SETTINGS_ENABLE_PUSH', flag: true };
 
 // * SETTINGS_MAX_CONCURRENT_STREAMS (4):
 //   indicates the maximum number of concurrent streams that the sender will allow.
-definedSettings[4] = { name: 'SETTINGS_MAX_CONCURRENT_STREAMS', flag: false };
+definedSettings[3] = { name: 'SETTINGS_MAX_CONCURRENT_STREAMS', flag: false };
 
 // * SETTINGS_INITIAL_WINDOW_SIZE (7):
 //   indicates the sender's initial stream window size (in bytes) for new streams.
-definedSettings[7] = { name: 'SETTINGS_INITIAL_WINDOW_SIZE', flag: false };
+definedSettings[4] = { name: 'SETTINGS_INITIAL_WINDOW_SIZE', flag: false };
 
-// * SETTINGS_FLOW_CONTROL_OPTIONS (10):
-//   indicates that streams directed to the sender will not be subject to flow control. The least
-//   significant bit (0x1) is set to indicate that new streams are not flow controlled. All other
-//   bits are reserved.
-definedSettings[10] = { name: 'SETTINGS_FLOW_CONTROL_OPTIONS', flag: true };
-
-// [PUSH_PROMISE](http://tools.ietf.org/html/draft-ietf-httpbis-http2-09#section-6.6)
+// [PUSH_PROMISE](http://tools.ietf.org/html/draft-ietf-httpbis-http2-10#section-6.6)
 // ---------------------------------------------------------------
 //
 // The PUSH_PROMISE frame (type=0x5) is used to notify the peer endpoint in advance of streams the
@@ -553,7 +600,7 @@ Deserializer.PUSH_PROMISE = function readPushPromise(buffer, frame) {
   frame.data = buffer.slice(4);
 };
 
-// [PING](http://tools.ietf.org/html/draft-ietf-httpbis-http2-09#section-6.7)
+// [PING](http://tools.ietf.org/html/draft-ietf-httpbis-http2-10#section-6.7)
 // -----------------------------------------------
 //
 // The PING frame (type=0x6) is a mechanism for measuring a minimal round-trip time from the
@@ -583,7 +630,7 @@ Deserializer.PING = function readPing(buffer, frame) {
   frame.data = buffer;
 };
 
-// [GOAWAY](http://tools.ietf.org/html/draft-ietf-httpbis-http2-09#section-6.8)
+// [GOAWAY](http://tools.ietf.org/html/draft-ietf-httpbis-http2-10#section-6.8)
 // ---------------------------------------------------
 //
 // The GOAWAY frame (type=0x7) informs the remote peer to stop creating streams on this connection.
@@ -630,14 +677,14 @@ Deserializer.GOAWAY = function readGoaway(buffer, frame) {
   frame.error = errorCodes[buffer.readUInt32BE(4)];
 };
 
-// [WINDOW_UPDATE](http://tools.ietf.org/html/draft-ietf-httpbis-http2-09#section-6.9)
+// [WINDOW_UPDATE](http://tools.ietf.org/html/draft-ietf-httpbis-http2-10#section-6.9)
 // -----------------------------------------------------------------
 //
-// The WINDOW_UPDATE frame (type=0x9) is used to implement flow control.
+// The WINDOW_UPDATE frame (type=0x8) is used to implement flow control.
 //
 // The WINDOW_UPDATE frame does not define any flags.
 
-frameTypes[0x9] = 'WINDOW_UPDATE';
+frameTypes[0x8] = 'WINDOW_UPDATE';
 
 frameFlags.WINDOW_UPDATE = [];
 
@@ -662,7 +709,7 @@ Deserializer.WINDOW_UPDATE = function readWindowUpdate(buffer, frame) {
   frame.window_size = buffer.readUInt32BE(0) & 0x7fffffff;
 };
 
-// [CONTINUATION](http://tools.ietf.org/html/draft-ietf-httpbis-http2-09#section-6.10)
+// [CONTINUATION](http://tools.ietf.org/html/draft-ietf-httpbis-http2-10#section-6.10)
 // ------------------------------------------------------------
 //
 // The CONTINUATION frame (type=0xA) is used to continue a sequence of header block fragments.
@@ -672,10 +719,16 @@ Deserializer.WINDOW_UPDATE = function readWindowUpdate(buffer, frame) {
 // * END_HEADERS (0x4):
 //   The END_HEADERS bit indicates that this frame ends the sequence of header block fragments
 //   necessary to provide a complete set of headers.
+// * PAD_LOW (0x10):
+//   Bit 5 being set indicates that the Pad Low field is present.
+// * PAD_HIGH (0x20):
+//   Bit 6 being set indicates that the Pad High field is present. This bit MUST NOT be set unless
+//   the PAD_LOW flag is also set. Endpoints that receive a frame with PAD_HIGH set and PAD_LOW
+//   cleared MUST treat this as a connection error of type PROTOCOL_ERROR.
 
-frameTypes[0xA] = 'CONTINUATION';
+frameTypes[0x9] = 'CONTINUATION';
 
-frameFlags.CONTINUATION = ['RESERVED1', 'RESERVED2', 'END_HEADERS'];
+frameFlags.CONTINUATION = ['RESERVED1', 'RESERVED2', 'END_HEADERS', 'RESERVED8', 'PAD_LOW', 'PAD_HIGH'];
 
 typeSpecificAttributes.CONTINUATION = ['headers', 'data'];
 
@@ -684,10 +737,26 @@ Serializer.CONTINUATION = function writeContinuation(frame, buffers) {
 };
 
 Deserializer.CONTINUATION = function readContinuation(buffer, frame) {
-  frame.data = buffer;
+  var dataOffset = 0;
+  var paddingLength = 0;
+  if (frame.flags.PAD_LOW) {
+    if (frame.flags.PAD_HIGH) {
+      paddingLength = (buffer.readUInt8(dataOffset) & 0xff) * 256;
+      dataOffset += 1;
+    }
+    paddingLength += (buffer.readUInt8(dataOffset) & 0xff);
+    dataOffset += 1;
+  } else if (frame.flags.PAD_HIGH) {
+    return 'CONTINUATION frame got PAD_HIGH without PAD_LOW';
+  }
+  if (paddingLength) {
+    frame.data = buffer.slice(dataOffset, -1 * paddingLength);
+  } else {
+    frame.data = buffer.slice(dataOffset);
+  }
 };
 
-// [Error Codes](http://tools.ietf.org/html/draft-ietf-httpbis-http2-09#section-7)
+// [Error Codes](http://tools.ietf.org/html/draft-ietf-httpbis-http2-10#section-7)
 // ------------------------------------------------------------
 
 var errorCodes = [

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-// [node-http2-protocol][homepage] is an implementation of the [HTTP/2 (draft 09)][http2]
+// [node-http2-protocol][homepage] is an implementation of the [HTTP/2 (draft 10)][http2]
 // framing layer for [node.js][node].
 //
 // The main building blocks are [node.js streams][node-stream] that are connected through pipes.
@@ -28,14 +28,16 @@
 //   between the binary and the JavaScript object representation of HTTP/2 frames
 //
 // [homepage]:            https://github.com/molnarg/node-http2
-// [http2]:               http://tools.ietf.org/html/draft-ietf-httpbis-http2-09
-// [http2-connheader]:    http://tools.ietf.org/html/draft-ietf-httpbis-http2-09#section-3.5
-// [http2-stream]:        http://tools.ietf.org/html/draft-ietf-httpbis-http2-09#section-5
-// [http2-streamstate]:   http://tools.ietf.org/html/draft-ietf-httpbis-http2-09#section-5.1
+// [http2]:               http://tools.ietf.org/html/draft-ietf-httpbis-http2-10
+// [http2-connheader]:    http://tools.ietf.org/html/draft-ietf-httpbis-http2-10#section-3.5
+// [http2-stream]:        http://tools.ietf.org/html/draft-ietf-httpbis-http2-10#section-5
+// [http2-streamstate]:   http://tools.ietf.org/html/draft-ietf-httpbis-http2-10#section-5.1
 // [node]:                http://nodejs.org/
 // [node-stream]:         http://nodejs.org/api/stream.html
 // [node-https]:          http://nodejs.org/api/https.html
 // [node-http]:           http://nodejs.org/api/http.html
+
+exports.ImplementedVersion = 'h2-10';
 
 exports.Endpoint = require('./endpoint').Endpoint;
 

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -322,7 +322,7 @@ Stream.prototype._finishing = function _finishing() {
   }
 };
 
-// [Stream States](http://tools.ietf.org/html/draft-ietf-httpbis-http2-09#section-5.1)
+// [Stream States](http://tools.ietf.org/html/draft-ietf-httpbis-http2-10#section-5.1)
 // ----------------
 //
 //                           +--------+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http2-protocol",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "A JavaScript implementation of the HTTP/2 framing layer",
   "main": "lib/index.js",
   "engines" : {

--- a/test/compressor.js
+++ b/test/compressor.js
@@ -49,14 +49,14 @@ test_huffman_request = {
 };
 
 test_huffman_response = {
-  '302': '409f',
-  'private': 'c31b39bf387f',
-  'Mon, 21 OCt 2013 20:13:21 GMT': 'a2fba20320f2ebcc0c490062d2434c827a1d',
-  ': https://www.bar.com': '6871cf3c326ebd7e9e9e926e7e32557dbf',
-  '200': '311f',
-  'Mon, 21 OCt 2013 20:13:22 GMT': 'a2fba20320f2ebcc0c490062d2434cc27a1d',
-  'https://www.bar.com': 'e39e7864dd7afd3d3d24dcfc64aafb7f',
-  'gzip': 'e1fbb30f',
+  '302': '98a7',
+  'private': '73d5cd111f',
+  'Mon, 21 OCt 2013 20:13:21 GMT': 'ef6b3a7a0e6e8fa7647a0e534dd072fb0d37b0e6e8f777f8ff',
+  ': https://www.bar.com': 'f6746718ba1ec00db6d897a1e44b74',
+  '200': '394b',
+  'Mon, 21 OCt 2013 20:13:22 GMT': 'ef6b3a7a0e6e8fa7647a0e534dd072fb0d37b0e7e8f777f8ff',
+  'https://www.bar.com': 'ce31743d801b6db12f43c896e9',
+  'gzip': 'cbd54e',
   'foo=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\
 AAAAAAAAAAAAAAAAAAAAAAAAAALASDJKHQKBZXOQWEOPIUAXQWEOIUAXLJKHQWOEIUAL\
 QWEOIUAXLQEUAXLLKJASDQWEOUIAXN1234LASDJKHQKBZXOQWEOPIUAXQWEOIUAXLJKH\
@@ -64,21 +64,22 @@ QWOEIUALQWEOIUAXLQEUAXLLKJASDQWEOUIAXN1234LASDJKHQKBZXOQWEOPIUAXQWEO\
 IUAXLJKHQWOEIUALQWEOIUAXLQEUAXLLKJASDQWEOUIAXN1234LASDJKHQKBZXOQWEOP\
 IUAXQWEOIUAXLJKHQWOEIUALQWEOIUAXLQEUAXLLKJASDQWEOUIAXN1234ZZZZZZZZZZ\
 ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ1234 m\
-ax-age=3600; version=1': 'df7dfb36eddbb76eddbb76eddbb76eddbb76eddbb76eddbb76\
-eddbb76eddbb76eddbb76eddbb76eddbb76eddbb76eddbb76eddbb76eddbb76eddbb\
-76eddbb76eddbb7e3b69ecf0fe7e1fd7f3d5fe7f7e5fd79f6f97cbbfe9b7fbfebcfb\
-7cbbfe9b7fbf8f87f3f0febcfcbb7bfe9b7e3fd79f6f977fd36ff7f1febb7e9b7fbf\
-8fc7f9f0db4f67f5e7dbe5f4efdbfdf891a13f1db4f6787f3f0febf9eaff3fbf2feb\
-cfb7cbe5dff4dbfdff5e7dbe5dff4dbfdfc7c3f9f87f5e7e5dbdff4dbf1febcfb7cb\
-bfe9b7fbf8ff5dbf4dbfdfc7e3fcf86da7b3faf3edf2fa77edfefc48d09f8eda7b3c\
-3f9f87f5fcf57f9fdf97f5e7dbe5f2effa6dfeffaf3edf2effa6dfefe3e1fcfc3faf\
-3f2edeffa6df8ff5e7dbe5dff4dbfdfc7faedfa6dfefe3f1fe7c36d3d9fd79f6f97d\
-3bf6ff7e24684fc76d3d9e1fcfc3fafe7abfcfefcbfaf3edf2f977fd36ff7fd79f6f\
-977fd36ff7f1f0fe7e1fd79f976f7fd36fc7faf3edf2effa6dfefe3fd76fd36ff7f1\
-f8ff3e1b69ecfebcfb7cbe9dfb7fbf123427fcff3fcff3fcff3fcff3fcff3fcff3fc\
-ff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3\
+ax-age=3600; version=1': 'c5adb77efdfbf7efdfbf7efdfbf7efdfbf7efdfbf7\
+efdfbf7efdfbf7efdfbf7efdfbf7efdfbf7efdfbf7efdfbf7efdfbf7efdfbf7efdfb\
+f7efdfbf7efdfbf7efdfbfe5bfc3b7e3fdfbfedfdf5ff9fbfa7dbf5ddf4fafc3f1bf\
+f7f6fd777d3e1f8dffbf97c7fbf7fdbf5f4eef87e37fcbedfaeefa7c3f1bff7f2fb7\
+77e37fefe5f2fefe3bfc3b7edfaeefa7e3e1bff7f331e69fe5bfc3b7e3fdfbfedfdf\
+5ff9fbfa7dbf5ddf4fafc3f1bff7f6fd777d3e1f8dffbf97c7fbf7fdbf5f4eef87e3\
+7fcbedfaeefa7c3f1bff7f2fb777e37fefe5f2fefe3bfc3b7edfaeefa7e3e1bff7f3\
+31e69fe5bfc3b7e3fdfbfedfdf5ff9fbfa7dbf5ddf4fafc3f1bff7f6fd777d3e1f8d\
+ffbf97c7fbf7fdbf5f4eef87e37fcbedfaeefa7c3f1bff7f2fb777e37fefe5f2fefe\
+3bfc3b7edfaeefa7e3e1bff7f331e69fe5bfc3b7e3fdfbfedfdf5ff9fbfa7dbf5ddf\
+4fafc3f1bff7f6fd777d3e1f8dffbf97c7fbf7fdbf5f4eef87e37fcbedfaeefa7c3f\
+1bff7f2fb777e37fefe5f2fefe3bfc3b7edfaeefa7e3e1bff7f331e69ffcff3fcff3\
 fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcf\
-f3fcff3fcff08d090b5fd237f086c44a23ef0e70c72b2fbb617f',
+f3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3f\
+cff3fcff3fcff3fcff3fcff3fcff3fcff0c79a7e8d11e72a321b66a4a5eae8e62f82\
+9acb4d',
   'foo=ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ\
 ZZZZZZZZZZZZZZZZZZZZZZZZZZLASDJKHQKBZXOQWEOPIUAXQWEOIUAXLJKHQWOEIUAL\
 QWEOIUAXLQEUAXLLKJASDQWEOUIAXN1234LASDJKHQKBZXOQWEOPIUAXQWEOIUAXLJKH\
@@ -86,21 +87,22 @@ QWOEIUALQWEOIUAXLQEUAXLLKJASDQWEOUIAXN1234LASDJKHQKBZXOQWEOPIUAXQWEO\
 IUAXLJKHQWOEIUALQWEOIUAXLQEUAXLLKJASDQWEOUIAXN1234LASDJKHQKBZXOQWEOP\
 IUAXQWEOIUAXLJKHQWOEIUALQWEOIUAXLQEUAXLLKJASDQWEOUIAXN1234AAAAAAAAAA\
 AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA1234 m\
-ax-age=3600; version=1': 'df7dfb3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcf\
-f3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3f\
+ax-age=3600; version=1': 'c5adb7fcff3fcff3fcff3fcff3fcff3fcff3fcff3f\
 cff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff\
-3e3b69ecf0fe7e1fd7f3d5fe7f7e5fd79f6f97cbbfe9b7fbfebcfb7cbbfe9b7fbf8f\
-87f3f0febcfcbb7bfe9b7e3fd79f6f977fd36ff7f1febb7e9b7fbf8fc7f9f0db4f67\
-f5e7dbe5f4efdbfdf891a13f1db4f6787f3f0febf9eaff3fbf2febcfb7cbe5dff4db\
-fdff5e7dbe5dff4dbfdfc7c3f9f87f5e7e5dbdff4dbf1febcfb7cbbfe9b7fbf8ff5d\
-bf4dbfdfc7e3fcf86da7b3faf3edf2fa77edfefc48d09f8eda7b3c3f9f87f5fcf57f\
-9fdf97f5e7dbe5f2effa6dfeffaf3edf2effa6dfefe3e1fcfc3faf3f2edeffa6df8f\
-f5e7dbe5dff4dbfdfc7faedfa6dfefe3f1fe7c36d3d9fd79f6f97d3bf6ff7e24684f\
-c76d3d9e1fcfc3fafe7abfcfefcbfaf3edf2f977fd36ff7fd79f6f977fd36ff7f1f0\
-fe7e1fd79f976f7fd36fc7faf3edf2effa6dfefe3fd76fd36ff7f1f8ff3e1b69ecfe\
-bcfb7cbe9dfb7fbf1234276eddbb76eddbb76eddbb76eddbb76eddbb76eddbb76edd\
-bb76eddbb76eddbb76eddbb76eddbb76eddbb76eddbb76eddbb76eddbb76eddbb76e\
-ddbb76eddbb48d090b5fd237f086c44a23ef0e70c72b2fbb617f'
+3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fc\
+ff3fcff3e5bfc3b7e3fdfbfedfdf5ff9fbfa7dbf5ddf4fafc3f1bff7f6fd777d3e1f\
+8dffbf97c7fbf7fdbf5f4eef87e37fcbedfaeefa7c3f1bff7f2fb777e37fefe5f2fe\
+fe3bfc3b7edfaeefa7e3e1bff7f331e69fe5bfc3b7e3fdfbfedfdf5ff9fbfa7dbf5d\
+df4fafc3f1bff7f6fd777d3e1f8dffbf97c7fbf7fdbf5f4eef87e37fcbedfaeefa7c\
+3f1bff7f2fb777e37fefe5f2fefe3bfc3b7edfaeefa7e3e1bff7f331e69fe5bfc3b7\
+e3fdfbfedfdf5ff9fbfa7dbf5ddf4fafc3f1bff7f6fd777d3e1f8dffbf97c7fbf7fd\
+bf5f4eef87e37fcbedfaeefa7c3f1bff7f2fb777e37fefe5f2fefe3bfc3b7edfaeef\
+a7e3e1bff7f331e69fe5bfc3b7e3fdfbfedfdf5ff9fbfa7dbf5ddf4fafc3f1bff7f6\
+fd777d3e1f8dffbf97c7fbf7fdbf5f4eef87e37fcbedfaeefa7c3f1bff7f2fb777e3\
+7fefe5f2fefe3bfc3b7edfaeefa7e3e1bff7f331e69f7efdfbf7efdfbf7efdfbf7ef\
+dfbf7efdfbf7efdfbf7efdfbf7efdfbf7efdfbf7efdfbf7efdfbf7efdfbf7efdfbf7\
+efdfbf7efdfbf7efdfbf7efdfbf7efdfbcc79a7e8d11e72a321b66a4a5eae8e62f82\
+9acb4d'
 };
 
 var test_headers = [{
@@ -198,9 +200,9 @@ var test_headers = [{
   header: {
     name: -1,
     value: -1,
-    index: false
+    index: true
   },
-  buffer: new Buffer('80', 'hex')
+  buffer: new Buffer('8080', 'hex')
 }];
 
 var test_header_sets = [{
@@ -258,12 +260,12 @@ describe('compressor.js', function() {
   describe('HuffmanTable', function() {
     describe('method encode(buffer)', function() {
       it('should return the Huffman encoded version of the input buffer', function() {
-        var table = HuffmanTable.requestHuffmanTable;
+        var table = HuffmanTable.huffmanTable;
         for (var decoded in test_huffman_request) {
           var encoded = test_huffman_request[decoded];
           expect(table.encode(new Buffer(decoded)).toString('hex')).to.equal(encoded);
         }
-        table = HuffmanTable.responseHuffmanTable;
+        table = HuffmanTable.huffmanTable;
         for (decoded in test_huffman_response) {
           encoded = test_huffman_response[decoded];
           expect(table.encode(new Buffer(decoded)).toString('hex')).to.equal(encoded);
@@ -272,12 +274,12 @@ describe('compressor.js', function() {
     })
     describe('method decode(buffer)', function() {
       it('should return the Huffman decoded version of the input buffer', function() {
-        var table = HuffmanTable.requestHuffmanTable;
+        var table = HuffmanTable.huffmanTable;
         for (var decoded in test_huffman_request) {
           var encoded = test_huffman_request[decoded];
           expect(table.decode(new Buffer(encoded, 'hex')).toString()).to.equal(decoded)
         }
-        table = HuffmanTable.responseHuffmanTable;
+        table = HuffmanTable.huffmanTable;
         for (decoded in test_huffman_response) {
           encoded = test_huffman_response[decoded];
           expect(table.decode(new Buffer(encoded, 'hex')).toString()).to.equal(decoded)
@@ -298,7 +300,7 @@ describe('compressor.js', function() {
     });
     describe('static method .string(string)', function() {
       it('should return an array of buffers that represent the encoded form of the string', function() {
-        var table = HuffmanTable.requestHuffmanTable;
+        var table = HuffmanTable.huffmanTable;
         for (var i = 0; i < test_strings.length; i++) {
           var test = test_strings[i];
           expect(util.concat(HeaderSetCompressor.string(test.string, table))).to.deep.equal(test.buffer);
@@ -307,7 +309,7 @@ describe('compressor.js', function() {
     });
     describe('static method .header({ name, value, index })', function() {
       it('should return an array of buffers that represent the encoded form of the header', function() {
-        var table = HuffmanTable.requestHuffmanTable;
+        var table = HuffmanTable.huffmanTable;
         for (var i = 0; i < test_headers.length; i++) {
           var test = test_headers[i];
           expect(util.concat(HeaderSetCompressor.header(test.header, table))).to.deep.equal(test.buffer);
@@ -329,7 +331,7 @@ describe('compressor.js', function() {
     });
     describe('static method .string(buffer)', function() {
       it('should return the parsed string and increase the cursor property of buffer', function() {
-        var table = HuffmanTable.requestHuffmanTable;
+        var table = HuffmanTable.huffmanTable;
         for (var i = 0; i < test_strings.length; i++) {
           var test = test_strings[i];
           test.buffer.cursor = 0;
@@ -340,7 +342,7 @@ describe('compressor.js', function() {
     });
     describe('static method .header(buffer)', function() {
       it('should return the parsed header and increase the cursor property of buffer', function() {
-        var table = HuffmanTable.requestHuffmanTable;
+        var table = HuffmanTable.huffmanTable;
         for (var i = 0; i < test_headers.length; i++) {
           var test = test_headers[i];
           test.buffer.cursor = 0;
@@ -428,7 +430,7 @@ describe('compressor.js', function() {
             buffer.push(Math.floor(Math.random() * 256))
           }
           buffer = new Buffer(buffer);
-          var table = HuffmanTable.requestHuffmanTable;
+          var table = HuffmanTable.huffmanTable;
           var result = table.decode(table.encode(buffer));
           expect(result).to.deep.equal(buffer);
         }

--- a/test/connection.js
+++ b/test/connection.js
@@ -63,47 +63,6 @@ describe('connection.js', function() {
       });
     });
     describe('invalid operation', function() {
-      describe('disabling and the re-enabling flow control', function() {
-        it('should result in an error event with type "FLOW_CONTROL_ERROR"', function(done) {
-          var connection = new Connection(util.log, 1, settings);
-
-          connection.on('error', function(error) {
-            expect(error).to.equal('FLOW_CONTROL_ERROR');
-            done();
-          });
-
-          connection._setLocalFlowControl(true);
-          connection._setLocalFlowControl(false);
-        });
-      });
-      describe('manipulating flow control window after flow control was turned off', function() {
-        it('should result in an error event with type "FLOW_CONTROL_ERROR"', function(done) {
-          var connection = new Connection(util.log, 1, settings);
-
-          connection.on('error', function(error) {
-            expect(error).to.equal('FLOW_CONTROL_ERROR');
-            done();
-          });
-
-          connection._setLocalFlowControl(true);
-          connection._setInitialStreamWindowSize(10);
-        });
-      });
-      describe('disabling flow control twice', function() {
-        it('should be ignored', function() {
-          var connection = new Connection(util.log, 1, settings);
-
-          connection._setLocalFlowControl(true);
-          connection._setLocalFlowControl(true);
-        });
-      });
-      describe('enabling flow control when already enabled', function() {
-        it('should be ignored', function() {
-          var connection = new Connection(util.log, 1, settings);
-
-          connection._setLocalFlowControl(false);
-        });
-      });
       describe('unsolicited ping answer', function() {
         it('should be ignored', function() {
           var connection = new Connection(util.log, 1, settings);

--- a/test/flow.js
+++ b/test/flow.js
@@ -82,13 +82,6 @@ describe('flow.js', function() {
 
       });
     });
-    describe('.disableLocalFlowControl() method', function() {
-      it('should increase `this._window` by Infinity', function() {
-        flow._send = util.noop;
-        flow.disableLocalFlowControl();
-        expect(flow._window).to.equal(Infinity);
-      });
-    });
     describe('.read() method', function() {
       describe('when the flow control queue is not empty', function() {
         it('should return the first item in the queue if the window is enough', function() {
@@ -132,7 +125,6 @@ describe('flow.js', function() {
     describe('.write() method', function() {
       it('call with a DATA frame should trigger sending WINDOW_UPDATE if remote flow control is not' +
          'disabled', function(done) {
-        flow._remoteFlowControlDisabled = false;
         flow._window = 100;
         flow._send = util.noop;
         flow._receive = function(frame, callback) {
@@ -159,7 +151,6 @@ describe('flow.js', function() {
       flow1 = createFlow({ flow: 1 });
       flow2 = createFlow({ flow: 2 });
       flow1._flowControlId = flow2._flowControlId;
-      flow1._remoteFlowControlDisabled = flow2._remoteFlowControlDisabled = false;
       flow1._send = flow2._send = util.noop;
       flow1._receive = flow2._receive = function(frame, callback) { callback(); };
     });

--- a/test/stream.js
+++ b/test/stream.js
@@ -7,7 +7,6 @@ var Stream = stream.Stream;
 function createStream() {
   var stream = new Stream(util.log);
   stream.upstream._window = Infinity;
-  stream.upstream._remoteFlowControlDisabled = true;
   return stream;
 }
 


### PR DESCRIPTION
Hey Gábor - coming off IETF this week, we were very excited to get draft10 landed in firefox, and of course to do that, we need node-http2 updated, as well. So, I took it upon myself to implement draft10 for node-http2 this week.

There is only one thing not implemented that draft10 requires, which is the TLS requirements enforcement. It seems that node's socket API doesn't expose enough information to actually enforce the requirements, so obviously I just couldn't do that bit :) Otherwise, everything required is done.

The other thing I left out is generating padding. That's probably something that should be implemented at some point, but isn't required for compliance (an implementation only needs to be able to handle padded frames sent to it).

I also have a pull request for node-http2 to update it to use this version of node-http2-protocol.
