### PR TITLE
Implement draft11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .idea
 coverage
 doc
+npm-debug.log

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,12 @@
 Version history
 ===============
 
+### 0.11.0 (2014-04-16) ###
+
+* Upgrade to the latest draft: [draft-ietf-httpbis-http2-11][draft-11]
+
+[draft-11]: http://tools.ietf.org/html/draft-ietf-httpbis-http2-11
+
 ### 0.10.0 (2014-03-12) ###
 
 * Upgrade to the latest draft: [draft-ietf-httpbis-http2-10][draft-10]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 node-http2-protocol
 ===================
 
-An HTTP/2 ([draft-ietf-httpbis-http2-10](http://tools.ietf.org/html/draft-ietf-httpbis-http2-10))
+An HTTP/2 ([draft-ietf-httpbis-http2-11](http://tools.ietf.org/html/draft-ietf-httpbis-http2-11))
 framing layer implementaion for node.js.
 
 Installation

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -122,7 +122,8 @@ Connection.prototype._initializeStreamManagement = function _initializeStreamMan
 // broadcasts the message by creating an event on it.
 Connection.prototype._writeControlFrame = function _writeControlFrame(frame) {
   if ((frame.type === 'SETTINGS') || (frame.type === 'PING') ||
-      (frame.type === 'GOAWAY') || (frame.type === 'WINDOW_UPDATE')) {
+      (frame.type === 'GOAWAY') || (frame.type === 'WINDOW_UPDATE') ||
+      (frame.type === 'ALTSVC')) {
     this._log.debug({ frame: frame }, 'Receiving connection level frame');
     this.emit(frame.type, frame);
   } else {

--- a/lib/flow.js
+++ b/lib/flow.js
@@ -19,7 +19,7 @@ exports.Flow = Flow;
 // * **setInitialWindow(size)**: the initial flow control window size can be changed *any time*
 //   ([as described in the standard][1]) using this method
 //
-// [1]: http://tools.ietf.org/html/draft-ietf-httpbis-http2-10#section-6.9.2
+// [1]: http://tools.ietf.org/html/draft-ietf-httpbis-http2-11#section-6.9.2
 
 // API for child classes
 // ---------------------

--- a/lib/framer.js
+++ b/lib/framer.js
@@ -148,7 +148,7 @@ Deserializer.prototype._transform = function _transform(chunk, encoding, done) {
   done();
 };
 
-// [Frame Header](http://tools.ietf.org/html/draft-ietf-httpbis-http2-10#section-4.1)
+// [Frame Header](http://tools.ietf.org/html/draft-ietf-httpbis-http2-11#section-4.1)
 // --------------------------------------------------------------
 //
 // HTTP/2.0 frames share a common base format consisting of an 8-byte header followed by 0 to 65535
@@ -262,7 +262,7 @@ Deserializer.commonHeader = function readCommonHeader(buffer, frame) {
 // * `typeSpecificAttributes`: a register of frame specific frame object attributes (used by
 //   logging code and also serves as documentation for frame objects)
 
-// [DATA Frames](http://tools.ietf.org/html/draft-ietf-httpbis-http2-10#section-6.1)
+// [DATA Frames](http://tools.ietf.org/html/draft-ietf-httpbis-http2-11#section-6.1)
 // ------------------------------------------------------------
 //
 // DATA frames (type=0x0) convey arbitrary, variable-length sequences of octets associated with a
@@ -277,16 +277,16 @@ Deserializer.commonHeader = function readCommonHeader(buffer, frame) {
 //   Bit 2 being set indicates that this frame is the last for the current segment. Intermediaries
 //   MUST NOT coalesce frames across a segment boundary and MUST preserve segment boundaries when
 //   forwarding frames.
-// * PAD_LOW (0x10):
+// * PAD_LOW (0x08):
 //   Bit 5 being set indicates that the Pad Low field is present.
-// * PAD_HIGH (0x20):
+// * PAD_HIGH (0x10):
 //   Bit 6 being set indicates that the Pad High field is present. This bit MUST NOT be set unless
 //   the PAD_LOW flag is also set. Endpoints that receive a frame with PAD_HIGH set and PAD_LOW
 //   cleared MUST treat this as a connection error of type PROTOCOL_ERROR.
 
 frameTypes[0x0] = 'DATA';
 
-frameFlags.DATA = ['END_STREAM', 'END_SEGMENT', 'RESERVED4', 'RESERVED8', 'PAD_LOW', 'PAD_HIGH'];
+frameFlags.DATA = ['END_STREAM', 'END_SEGMENT', 'RESERVED4', 'PAD_LOW', 'PAD_HIGH'];
 
 typeSpecificAttributes.DATA = ['data'];
 
@@ -314,7 +314,7 @@ Deserializer.DATA = function readData(buffer, frame) {
   }
 };
 
-// [HEADERS](http://tools.ietf.org/html/draft-ietf-httpbis-http2-10#section-6.2)
+// [HEADERS](http://tools.ietf.org/html/draft-ietf-httpbis-http2-11#section-6.2)
 // --------------------------------------------------------------
 //
 // The HEADERS frame (type=0x1) allows the sender to create a stream.
@@ -331,37 +331,52 @@ Deserializer.DATA = function readData(buffer, frame) {
 // * END_HEADERS (0x4):
 //   The END_HEADERS bit indicates that this frame contains the entire payload necessary to provide
 //   a complete set of headers.
-// * PRIORITY (0x8):
-//   Bit 4 being set indicates that the first four octets of this frame contain a single reserved
-//   bit and a 31-bit priority.
-// * PAD_LOW (0x10):
+// * PAD_LOW (0x08):
 //   Bit 5 being set indicates that the Pad Low field is present.
-// * PAD_HIGH (0x20):
+// * PAD_HIGH (0x10):
 //   Bit 6 being set indicates that the Pad High field is present. This bit MUST NOT be set unless
 //   the PAD_LOW flag is also set. Endpoints that receive a frame with PAD_HIGH set and PAD_LOW
 //   cleared MUST treat this as a connection error of type PROTOCOL_ERROR.
 
 frameTypes[0x1] = 'HEADERS';
 
-frameFlags.HEADERS = ['END_STREAM', 'END_SEGMENT', 'END_HEADERS', 'PRIORITY', 'PAD_LOW', 'PAD_HIGH'];
+frameFlags.HEADERS = ['END_STREAM', 'END_SEGMENT', 'END_HEADERS', 'PAD_LOW', 'PAD_HIGH', 'PRIORITY_GROUP', 'PRIORITY_DEPENDENCY'];
 
-typeSpecificAttributes.HEADERS = ['priority', 'headers', 'data'];
+typeSpecificAttributes.HEADERS = ['priorityGroup', 'groupWeight', 'priorityDependency', 'exclusiveDependency', 'headers', 'data'];
 
 //      0                   1                   2                   3
 //      0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
 //     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-//     |X|               (Optional) Priority (31)                      |
+//     | Pad High? (8) |  Pad Low? (8) |
+//     +-+-------------+---------------+-------------------------------+
+//     |R|              Priority Group Identifier? (31)                |
+//     +-+-------------+-----------------------------------------------+
+//     |  Weight? (8)  |
+//     +-+-------------+-----------------------------------------------+
+//     |E|                 Stream Dependency? (31)                     |
 //     +-+-------------------------------------------------------------+
-//     |                    Header Block (*)                         ...
+//     |                   Header Block Fragment (*)                 ...
+//     +---------------------------------------------------------------+
+//     |                           Padding (*)                       ...
 //     +---------------------------------------------------------------+
 //
 // The payload of a HEADERS frame contains a Headers Block
 
 Serializer.HEADERS = function writeHeadersPriority(frame, buffers) {
-  if (frame.flags.PRIORITY) {
+  if (frame.flags.PRIORITY_GROUP) {
+    var buffer = new Buffer(5);
+    assert((0 <= frame.priorityGroup) && (frame.priorityGroup <= 0x7fffffff), frame.priorityGroup);
+    buffer.writeUInt32BE(frame.priorityGroup, 0);
+    assert((0 <= frame.groupWeight) && (frame.groupWeight <= 0xff), frame.groupWeight);
+    buffer.writeUInt8(frame.groupWeight, 4);
+    buffers.push(buffer);
+  } else if (frame.flags.PRIORITY_DEPENDENCY) {
     var buffer = new Buffer(4);
-    assert((0 <= frame.priority) && (frame.priority <= 0xffffffff), frame.priority);
-    buffer.writeUInt32BE(frame.priority, 0);
+    assert((0 <= frame.priorityDependency) && (frame.priorityDependency <= 0x7fffffff), frame.priorityDependency);
+    buffer.writeUInt32BE(frame.priorityDependency, 0);
+    if (frame.exclusiveDependency) {
+      buffer[0] |= 0x80;
+    }
     buffers.push(buffer);
   }
   buffers.push(frame.data);
@@ -380,10 +395,24 @@ Deserializer.HEADERS = function readHeadersPriority(buffer, frame) {
   } else if (frame.flags.PAD_HIGH) {
     return 'HEADERS frame got PAD_HIGH without PAD_LOW';
   }
-  if (frame.flags.PRIORITY) {
-    frame.priority = buffer.readUInt32BE(dataOffset) & 0x7fffffff;
+
+  if (frame.flags.PRIORITY_GROUP) {
+    if (frame.flags.PRIORITY_DEPENDENCY) {
+      return 'HEADERS frame got both PRIORITY_GROUP and PRIORITY_DEPENDENCY';
+    }
+    frame.priorityGroup = buffer.readUInt32BE(dataOffset) & 0x7fffffff;
     dataOffset += 4;
+    frame.groupWeight = buffer.readUInt8(dataOffset);
+    dataOffset += 1;
+  } else if (frame.flags.PRIORITY_DEPENDENCY) {
+    var dependencyData = new Buffer(4);
+    buffer.copy(dependencyData, 0, dataOffset, dataOffset + 4);
+    dataOffset += 4;
+    frame.exclusiveDependency = !!(dependencyData[0] & 0x80);
+    dependencyData[0] &= 0x7f;
+    frame.priorityDependency = dependencyData.readUInt32BE(0);
   }
+
   if (paddingLength) {
     frame.data = buffer.slice(dataOffset, -1 * paddingLength);
   } else {
@@ -391,7 +420,7 @@ Deserializer.HEADERS = function readHeadersPriority(buffer, frame) {
   }
 };
 
-// [PRIORITY](http://tools.ietf.org/html/draft-ietf-httpbis-http2-10#section-6.3)
+// [PRIORITY](http://tools.ietf.org/html/draft-ietf-httpbis-http2-11#section-6.3)
 // -------------------------------------------------------
 //
 // The PRIORITY frame (type=0x2) specifies the sender-advised priority of a stream.
@@ -400,29 +429,66 @@ Deserializer.HEADERS = function readHeadersPriority(buffer, frame) {
 
 frameTypes[0x2] = 'PRIORITY';
 
-frameFlags.PRIORITY = [];
+frameFlags.PRIORITY = ['RESERVED1', 'RESERVED2', 'RESERVED4', 'RESERVED8', 'RESERVED16', 'PRIORITY_GROUP', 'PRIORITY_DEPENDENCY'];
 
-typeSpecificAttributes.PRIORITY = ['priority'];
+typeSpecificAttributes.PRIORITY = ['priorityGroup', 'groupWeight', 'priorityDependency', 'exclusiveDependency'];
 
 //      0                   1                   2                   3
 //      0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
 //     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-//     |X|                   Priority (31)                             |
+//     |R|              Priority Group Identifier? (31)                |
+//     +-+-------------+-----------------------------------------------+
+//     |  Weight? (8)  |
+//     +-+-------------+-----------------------------------------------+
+//     |E|                 Stream Dependency? (31)                     |
 //     +-+-------------------------------------------------------------+
 //
 // The payload of a PRIORITY frame contains a single reserved bit and a 31-bit priority.
 
 Serializer.PRIORITY = function writePriority(frame, buffers) {
-  var buffer = new Buffer(4);
-  buffer.writeUInt32BE(frame.priority, 0);
+  var buffer;
+
+  assert((frame.flags.PRIORITY_GROUP || frame.flags.PRIORITY_DEPENDENCY) &&
+          !(frame.flags.PRIORITY_GROUP && frame.flags.PRIORITY_DEPENDENCY),
+         frame.flags.PRIORITY_GROUP && frame.flags.PRIORITY_DEPENDENCY);
+
+  if (frame.flags.PRIORITY_GROUP) {
+    buffer = new Buffer(5);
+    assert((0 <= frame.priorityGroup) && (frame.priorityGroup <= 0x7fffffff), frame.priorityGroup);
+    buffer.writeUInt32BE(frame.priorityGroup, 0);
+    assert((0 <= frame.groupWeight) && (frame.groupWeight <= 0xff), frame.groupWeight);
+    buffer.writeUInt8(frame.groupWeight, 4);
+  } else { // frame.flags.PRIORITY_DEPENDENCY
+    buffer = new Buffer(4);
+    assert((0 <= frame.priorityDependency) && (frame.priorityDependency <= 0x7fffffff), frame.priorityDependency);
+    buffer.writeUInt32BE(frame.priorityDependency, 0);
+    if (frame.exclusiveDependency) {
+      buffer[0] |= 0x80;
+    }
+  }
+
   buffers.push(buffer);
 };
 
 Deserializer.PRIORITY = function readPriority(buffer, frame) {
-  frame.priority = buffer.readUInt32BE(0);
+  if (frame.flags.PRIORITY_GROUP) {
+    if (frame.flags.PRIORITY_DEPENDENCY) {
+      return 'PRIORITY frame got both PRIORITY_GROUP and PRIORITY_DEPENDENCY';
+    }
+    frame.priorityGroup = buffer.readUInt32BE(0) & 0x7fffffff;
+    frame.groupWeight = buffer.readUInt8(4);
+  } else if (frame.flags.PRIORITY_DEPENDENCY) {
+    var dependencyData = new Buffer(4);
+    buffer.copy(dependencyData, 0, 0, 4);
+    frame.exclusiveDependency = !!(dependencyData[0] & 0x80);
+    dependencyData[0] &= 0x7f;
+    frame.priorityDependency = dependencyData.readUInt32BE(0);
+  } else {
+    return 'PRIORITY frame got neither PRIORITY_GROUP nor PRIORITY_DEPENDENCY';
+  }
 };
 
-// [RST_STREAM](http://tools.ietf.org/html/draft-ietf-httpbis-http2-10#section-6.4)
+// [RST_STREAM](http://tools.ietf.org/html/draft-ietf-httpbis-http2-11#section-6.4)
 // -----------------------------------------------------------
 //
 // The RST_STREAM frame (type=0x3) allows for abnormal termination of a stream.
@@ -456,7 +522,7 @@ Deserializer.RST_STREAM = function readRstStream(buffer, frame) {
   frame.error = errorCodes[buffer.readUInt32BE(0)];
 };
 
-// [SETTINGS](http://tools.ietf.org/html/draft-ietf-httpbis-http2-10#section-6.5)
+// [SETTINGS](http://tools.ietf.org/html/draft-ietf-httpbis-http2-11#section-6.5)
 // -------------------------------------------------------
 //
 // The SETTINGS frame (type=0x4) conveys configuration parameters that affect how endpoints
@@ -562,7 +628,7 @@ definedSettings[3] = { name: 'SETTINGS_MAX_CONCURRENT_STREAMS', flag: false };
 //   indicates the sender's initial stream window size (in bytes) for new streams.
 definedSettings[4] = { name: 'SETTINGS_INITIAL_WINDOW_SIZE', flag: false };
 
-// [PUSH_PROMISE](http://tools.ietf.org/html/draft-ietf-httpbis-http2-10#section-6.6)
+// [PUSH_PROMISE](http://tools.ietf.org/html/draft-ietf-httpbis-http2-11#section-6.6)
 // ---------------------------------------------------------------
 //
 // The PUSH_PROMISE frame (type=0x5) is used to notify the peer endpoint in advance of streams the
@@ -576,7 +642,7 @@ definedSettings[4] = { name: 'SETTINGS_INITIAL_WINDOW_SIZE', flag: false };
 
 frameTypes[0x5] = 'PUSH_PROMISE';
 
-frameFlags.PUSH_PROMISE = ['RESERVED1', 'RESERVED2', 'END_PUSH_PROMISE'];
+frameFlags.PUSH_PROMISE = ['RESERVED1', 'RESERVED2', 'END_PUSH_PROMISE', 'PAD_LOW', 'PAD_HIGH'];
 
 typeSpecificAttributes.PUSH_PROMISE = ['promised_stream', 'headers', 'data'];
 
@@ -604,11 +670,28 @@ Serializer.PUSH_PROMISE = function writePushPromise(frame, buffers) {
 };
 
 Deserializer.PUSH_PROMISE = function readPushPromise(buffer, frame) {
-  frame.promised_stream = buffer.readUInt32BE(0) & 0x7fffffff;
-  frame.data = buffer.slice(4);
+  var dataOffset = 0;
+  var paddingLength = 0;
+  if (frame.flags.PAD_LOW) {
+    if (frame.flags.PAD_HIGH) {
+      paddingLength = (buffer.readUInt8(dataOffset) & 0xff) * 256;
+      dataOffset += 1;
+    }
+    paddingLength += (buffer.readUInt8(dataOffset) & 0xff);
+    dataOffset += 1;
+  } else if (frame.flags.PAD_HIGH) {
+    return 'PUSH_PROMISE frame got PAD_HIGH without PAD_LOW';
+  }
+  frame.promised_stream = buffer.readUInt32BE(dataOffset) & 0x7fffffff;
+  dataOffset += 4;
+  if (paddingLength) {
+    frame.data = buffer.slice(dataOffset, -1 * paddingLength);
+  } else {
+    frame.data = buffer.slice(dataOffset);
+  }
 };
 
-// [PING](http://tools.ietf.org/html/draft-ietf-httpbis-http2-10#section-6.7)
+// [PING](http://tools.ietf.org/html/draft-ietf-httpbis-http2-11#section-6.7)
 // -----------------------------------------------
 //
 // The PING frame (type=0x6) is a mechanism for measuring a minimal round-trip time from the
@@ -638,7 +721,7 @@ Deserializer.PING = function readPing(buffer, frame) {
   frame.data = buffer;
 };
 
-// [GOAWAY](http://tools.ietf.org/html/draft-ietf-httpbis-http2-10#section-6.8)
+// [GOAWAY](http://tools.ietf.org/html/draft-ietf-httpbis-http2-11#section-6.8)
 // ---------------------------------------------------
 //
 // The GOAWAY frame (type=0x7) informs the remote peer to stop creating streams on this connection.
@@ -685,7 +768,7 @@ Deserializer.GOAWAY = function readGoaway(buffer, frame) {
   frame.error = errorCodes[buffer.readUInt32BE(4)];
 };
 
-// [WINDOW_UPDATE](http://tools.ietf.org/html/draft-ietf-httpbis-http2-10#section-6.9)
+// [WINDOW_UPDATE](http://tools.ietf.org/html/draft-ietf-httpbis-http2-11#section-6.9)
 // -----------------------------------------------------------------
 //
 // The WINDOW_UPDATE frame (type=0x8) is used to implement flow control.
@@ -720,26 +803,26 @@ Deserializer.WINDOW_UPDATE = function readWindowUpdate(buffer, frame) {
   frame.window_size = buffer.readUInt32BE(0) & 0x7fffffff;
 };
 
-// [CONTINUATION](http://tools.ietf.org/html/draft-ietf-httpbis-http2-10#section-6.10)
+// [CONTINUATION](http://tools.ietf.org/html/draft-ietf-httpbis-http2-11#section-6.10)
 // ------------------------------------------------------------
 //
-// The CONTINUATION frame (type=0xA) is used to continue a sequence of header block fragments.
+// The CONTINUATION frame (type=0x9) is used to continue a sequence of header block fragments.
 //
 // The CONTINUATION frame defines the following flag:
 //
 // * END_HEADERS (0x4):
 //   The END_HEADERS bit indicates that this frame ends the sequence of header block fragments
 //   necessary to provide a complete set of headers.
-// * PAD_LOW (0x10):
+// * PAD_LOW (0x08):
 //   Bit 5 being set indicates that the Pad Low field is present.
-// * PAD_HIGH (0x20):
+// * PAD_HIGH (0x10):
 //   Bit 6 being set indicates that the Pad High field is present. This bit MUST NOT be set unless
 //   the PAD_LOW flag is also set. Endpoints that receive a frame with PAD_HIGH set and PAD_LOW
 //   cleared MUST treat this as a connection error of type PROTOCOL_ERROR.
 
 frameTypes[0x9] = 'CONTINUATION';
 
-frameFlags.CONTINUATION = ['RESERVED1', 'RESERVED2', 'END_HEADERS', 'RESERVED8', 'PAD_LOW', 'PAD_HIGH'];
+frameFlags.CONTINUATION = ['RESERVED1', 'RESERVED2', 'END_HEADERS', 'PAD_LOW', 'PAD_HIGH'];
 
 typeSpecificAttributes.CONTINUATION = ['headers', 'data'];
 
@@ -767,7 +850,96 @@ Deserializer.CONTINUATION = function readContinuation(buffer, frame) {
   }
 };
 
-// [Error Codes](http://tools.ietf.org/html/draft-ietf-httpbis-http2-10#section-7)
+// [ALTSVC](http://tools.ietf.org/html/draft-ietf-httpbis-http2-11#section-6.11)
+// ------------------------------------------------------------
+//
+// The ALTSVC frame (type=0xA) advertises the availability of an alternative service to the client.
+//
+// The ALTSVC frame does not define any flags.
+
+frameTypes[0xA] = 'ALTSVC';
+
+frameFlags.ALTSVC = [];
+
+//     0                   1                   2                   3
+//     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+//    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//    |                          Max-Age (32)                         |
+//    +-------------------------------+----------------+--------------+
+//    |            Port (16)          |  Reserved (8)  | PID_LEN (8)  |
+//    +-------------------------------+----------------+--------------+
+//    |                        Protocol-ID (*)                        |
+//    +---------------+-----------------------------------------------+
+//    | HOST_LEN (8)  |                   Host (*)                  ...
+//    +---------------+-----------------------------------------------+
+//    |                          Origin? (*)                        ...
+//    +---------------------------------------------------------------+
+//
+// The ALTSVC frame contains the following fields:
+//
+// Max-Age: An unsigned, 32-bit integer indicating the freshness
+//    lifetime of the alternative service association, as per [ALT-SVC](http://tools.ietf.org/html/draft-ietf-httpbis-alt-svc-01)
+//    section 2.2.
+//
+// Port: An unsigned, 16-bit integer indicating the port that the
+//    alternative service is available upon.
+//
+// Reserved: For future use. Senders MUST set these bits to '0', and
+//    recipients MUST ignore them.
+//
+// PID_LEN: An unsigned, 8-bit integer indicating the length, in
+//    octets, of the Protocol-ID field.
+//
+// Protocol-ID: A sequence of bytes (length determined by PID_LEN)
+//    containing the ALPN protocol identifier of the alternative
+//    service.
+//
+// HOST_LEN: An unsigned, 8-bit integer indicating the length, in
+//    octets, of the Host field.
+//
+// Host: A sequence of characters (length determined by HOST_LEN)
+//    containing an ASCII string indicating the host that the
+//    alternative service is available upon. An internationalized
+//    domain [IDNA] MUST be expressed using A-labels.
+//
+// Origin: An optional sequence of characters (length determined by
+//    subtracting the length of all lpreceding fields from the frame
+//    length) containing ASCII serialisation of an origin ([RFC6454](http://tools.ietf.org/html/rfc6454),
+//    Section 6.2) that the alternate service is applicable to.
+
+typeSpecificAttributes.ALTSVC = ['maxAge', 'port', 'protocolID', 'host',
+                                 'origin'];
+
+Serializer.ALTSVC = function writeAltSvc(frame, buffers) {
+  var buffer = new Buffer(8);
+  buffer.writeUInt32BE(frame.maxAge, 0);
+  buffer.writeUInt16BE(frame.port, 4);
+  buffer.writeUInt8(0, 6);
+  buffer.writeUInt8(frame.protocolID.length, 7);
+  buffers.push(buffer);
+
+  buffers.push(new Buffer(frame.protocolID, 'ascii'));
+
+  buffer = new Buffer(1);
+  buffer.writeUInt8(frame.host.length, 0);
+  buffers.push(buffer);
+
+  buffers.push(new Buffer(frame.host, 'ascii'));
+
+  buffers.push(new Buffer(frame.origin, 'ascii'));
+};
+
+Deserializer.ALTSVC = function readAltSvc(buffer, frame) {
+  frame.maxAge = buffer.readUInt32BE(0);
+  frame.port = buffer.readUInt16BE(4);
+  var pidLength = buffer.readUInt8(7);
+  frame.protocolID = buffer.toString('ascii', 8, 8 + pidLength);
+  var hostLength = buffer.readUInt8(8 + pidLength);
+  frame.host = buffer.toString('ascii', 9 + pidLength, 9 + pidLength + hostLength);
+  frame.origin = buffer.toString('ascii', 9 + pidLength + hostLength);
+};
+
+// [Error Codes](http://tools.ietf.org/html/draft-ietf-httpbis-http2-11#section-7)
 // ------------------------------------------------------------
 
 var errorCodes = [
@@ -781,9 +953,10 @@ var errorCodes = [
   'REFUSED_STREAM',
   'CANCEL',
   'COMPRESSION_ERROR',
-  'CONNECT_ERROR'
+  'CONNECT_ERROR',
+  'ENHANCE_YOUR_CALM',
+  'INADEQUATE_SECURITY'
 ];
-errorCodes[420] = 'ENHANCE_YOUR_CALM';
 
 // Logging
 // -------

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-// [node-http2-protocol][homepage] is an implementation of the [HTTP/2 (draft 10)][http2]
+// [node-http2-protocol][homepage] is an implementation of the [HTTP/2 (draft 11)][http2]
 // framing layer for [node.js][node].
 //
 // The main building blocks are [node.js streams][node-stream] that are connected through pipes.
@@ -28,16 +28,16 @@
 //   between the binary and the JavaScript object representation of HTTP/2 frames
 //
 // [homepage]:            https://github.com/molnarg/node-http2
-// [http2]:               http://tools.ietf.org/html/draft-ietf-httpbis-http2-10
-// [http2-connheader]:    http://tools.ietf.org/html/draft-ietf-httpbis-http2-10#section-3.5
-// [http2-stream]:        http://tools.ietf.org/html/draft-ietf-httpbis-http2-10#section-5
-// [http2-streamstate]:   http://tools.ietf.org/html/draft-ietf-httpbis-http2-10#section-5.1
+// [http2]:               http://tools.ietf.org/html/draft-ietf-httpbis-http2-11
+// [http2-connheader]:    http://tools.ietf.org/html/draft-ietf-httpbis-http2-11#section-3.5
+// [http2-stream]:        http://tools.ietf.org/html/draft-ietf-httpbis-http2-11#section-5
+// [http2-streamstate]:   http://tools.ietf.org/html/draft-ietf-httpbis-http2-11#section-5.1
 // [node]:                http://nodejs.org/
 // [node-stream]:         http://nodejs.org/api/stream.html
 // [node-https]:          http://nodejs.org/api/https.html
 // [node-http]:           http://nodejs.org/api/http.html
 
-exports.ImplementedVersion = 'h2-10';
+exports.ImplementedVersion = 'h2-11';
 
 exports.Endpoint = require('./endpoint').Endpoint;
 

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -225,6 +225,8 @@ Stream.prototype._writeUpstream = function _writeUpstream(frame) {
     this._onPromise(frame);
   } else if (frame.type === 'PRIORITY') {
     this._onPriority(frame);
+  } else if (frame.type === 'ALTSVC') {
+    // TODO
   }
 
   // * If it's an invalid stream level frame, emit error
@@ -322,7 +324,7 @@ Stream.prototype._finishing = function _finishing() {
   }
 };
 
-// [Stream States](http://tools.ietf.org/html/draft-ietf-httpbis-http2-10#section-5.1)
+// [Stream States](http://tools.ietf.org/html/draft-ietf-httpbis-http2-11#section-5.1)
 // ----------------
 //
 //                           +--------+
@@ -382,7 +384,7 @@ Stream.prototype._transition = function transition(sending, frame) {
   var connectionError;
   var streamError;
 
-  var DATA = false, HEADERS = false, PRIORITY = false;
+  var DATA = false, HEADERS = false, PRIORITY = false, ALTSVC = false;
   var RST_STREAM = false, PUSH_PROMISE = false, WINDOW_UPDATE = false;
   switch(frame.type) {
     case 'DATA'         : DATA          = true; break;
@@ -391,6 +393,7 @@ Stream.prototype._transition = function transition(sending, frame) {
     case 'RST_STREAM'   : RST_STREAM    = true; break;
     case 'PUSH_PROMISE' : PUSH_PROMISE  = true; break;
     case 'WINDOW_UPDATE': WINDOW_UPDATE = true; break;
+    case 'ALTSVC'       : ALTSVC        = true; break;
   }
 
   var previousState = this.state;
@@ -533,7 +536,7 @@ Stream.prototype._transition = function transition(sending, frame) {
     case 'CLOSED':
       if ((sending && RST_STREAM) ||
           (receiving && this._closedByUs &&
-           (this._closedWithRst || WINDOW_UPDATE || PRIORITY || RST_STREAM))) {
+           (this._closedWithRst || WINDOW_UPDATE || PRIORITY || RST_STREAM || ALTSVC))) {
         /* No state change */
       } else {
         streamError = 'STREAM_CLOSED';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http2-protocol",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "A JavaScript implementation of the HTTP/2 framing layer",
   "main": "lib/index.js",
   "engines" : {

--- a/test/compressor.js
+++ b/test/compressor.js
@@ -29,34 +29,34 @@ var test_integers = [{
 
 var test_strings = [{
   string: 'www.foo.com',
-  buffer: new Buffer('88db6d898b5a44b74f', 'hex')
+  buffer: new Buffer('89e7cf9bfc1ad7d4db7f', 'hex')
 }, {
   string: 'éáűőúöüó€',
-  buffer: new Buffer('13C3A9C3A1C5B1C591C3BAC3B6C3BCC3B3E282AC', 'hex')
+  buffer: new Buffer('13c3a9c3a1c5b1c591c3bac3b6c3bcc3b3e282ac', 'hex')
 }];
 
 test_huffman_request = {
-  'GET': 'f77778ff',
-  'http': 'ce3177',
-  '/': '0f',
-  'www.foo.com': 'db6d898b5a44b74f',
-  'https': 'ce31743f',
-  'www.bar.com': 'db6d897a1e44b74f',
-  'no-cache': '63654a1398ff',
-  '/custom-path.css': '04eb08b7495c88e644c21f',
-  'custom-key': '4eb08b749790fa7f',
-  'custom-value': '4eb08b74979a17a8ff'
+  'GET': 'd5df47',
+  'http': 'adcebf',
+  '/': '3f',
+  'www.foo.com': 'e7cf9bfc1ad7d4db7f',
+  'https': 'adcebf1f',
+  'www.bar.com': 'e7cf9bfbd383ea6dbf',
+  'no-cache': 'b9b9949556bf',
+  '/custom-path.css': '3ab8e2e6db9af4bab7d58e3f',
+  'custom-key': '571c5cdb737b2faf',
+  'custom-value': '571c5cdb73724d9c57'
 };
 
 test_huffman_response = {
-  '302': '98a7',
-  'private': '73d5cd111f',
-  'Mon, 21 OCt 2013 20:13:21 GMT': 'ef6b3a7a0e6e8fa7647a0e534dd072fb0d37b0e6e8f777f8ff',
-  ': https://www.bar.com': 'f6746718ba1ec00db6d897a1e44b74',
-  '200': '394b',
-  'Mon, 21 OCt 2013 20:13:22 GMT': 'ef6b3a7a0e6e8fa7647a0e534dd072fb0d37b0e7e8f777f8ff',
-  'https://www.bar.com': 'ce31743d801b6db12f43c896e9',
-  'gzip': 'cbd54e',
+  '302': '4017',
+  'private': 'bf06724b97',
+  'Mon, 21 OCt 2013 20:13:21 GMT': 'd6dbb29884de3dce3100a0c4130a262136ad747f',
+  ': https://www.bar.com': '98d5b9d7e331cfcf9f37f7a707d4db7f',
+  '200': '200f',
+  'Mon, 21 OCt 2013 20:13:22 GMT': 'd6dbb29884de3dce3100a0c4130a262236ad747f',
+  'https://www.bar.com': 'adcebf198e7e7cf9bfbd383ea6db',
+  'gzip': 'abdd97ff',
   'foo=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\
 AAAAAAAAAAAAAAAAAAAAAAAAAALASDJKHQKBZXOQWEOPIUAXQWEOIUAXLJKHQWOEIUAL\
 QWEOIUAXLQEUAXLLKJASDQWEOUIAXN1234LASDJKHQKBZXOQWEOPIUAXQWEOIUAXLJKH\
@@ -64,22 +64,7 @@ QWOEIUALQWEOIUAXLQEUAXLLKJASDQWEOUIAXN1234LASDJKHQKBZXOQWEOPIUAXQWEO\
 IUAXLJKHQWOEIUALQWEOIUAXLQEUAXLLKJASDQWEOUIAXN1234LASDJKHQKBZXOQWEOP\
 IUAXQWEOIUAXLJKHQWOEIUALQWEOIUAXLQEUAXLLKJASDQWEOUIAXN1234ZZZZZZZZZZ\
 ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ1234 m\
-ax-age=3600; version=1': 'c5adb77efdfbf7efdfbf7efdfbf7efdfbf7efdfbf7\
-efdfbf7efdfbf7efdfbf7efdfbf7efdfbf7efdfbf7efdfbf7efdfbf7efdfbf7efdfb\
-f7efdfbf7efdfbf7efdfbfe5bfc3b7e3fdfbfedfdf5ff9fbfa7dbf5ddf4fafc3f1bf\
-f7f6fd777d3e1f8dffbf97c7fbf7fdbf5f4eef87e37fcbedfaeefa7c3f1bff7f2fb7\
-77e37fefe5f2fefe3bfc3b7edfaeefa7e3e1bff7f331e69fe5bfc3b7e3fdfbfedfdf\
-5ff9fbfa7dbf5ddf4fafc3f1bff7f6fd777d3e1f8dffbf97c7fbf7fdbf5f4eef87e3\
-7fcbedfaeefa7c3f1bff7f2fb777e37fefe5f2fefe3bfc3b7edfaeefa7e3e1bff7f3\
-31e69fe5bfc3b7e3fdfbfedfdf5ff9fbfa7dbf5ddf4fafc3f1bff7f6fd777d3e1f8d\
-ffbf97c7fbf7fdbf5f4eef87e37fcbedfaeefa7c3f1bff7f2fb777e37fefe5f2fefe\
-3bfc3b7edfaeefa7e3e1bff7f331e69fe5bfc3b7e3fdfbfedfdf5ff9fbfa7dbf5ddf\
-4fafc3f1bff7f6fd777d3e1f8dffbf97c7fbf7fdbf5f4eef87e37fcbedfaeefa7c3f\
-1bff7f2fb777e37fefe5f2fefe3bfc3b7edfaeefa7e3e1bff7f331e69ffcff3fcff3\
-fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcf\
-f3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3f\
-cff3fcff3fcff3fcff3fcff3fcff3fcff0c79a7e8d11e72a321b66a4a5eae8e62f82\
-9acb4d',
+ax-age=3600; version=1': 'e0d6cf9f3e7cf9f3e7cf9f3e7cf9f3e7cf9f3e7cf9f3e7cf9f3e7cf9f3e7cf9f3e7cf9f3e7cf9f3e7cf9f3e7cf9f3e7cf9f3e7cf9f3e7cf9f3e7cf9f3e7cf9f3e7cff5cfb747cfe9f2fb7d3b7f7e9e3f6fcf7f8f97879e7f4fb7e7bfc7c3cf3fa7d7e7f4f97dbf3e3dfe1e79febf6fcf7f8f879e7f4fafdbbfcf3fa7d7ebf4f9e7dba3edf9eff1f3f0cfe9b049107d73edd1f3fa7cbedf4edfdfa78fdbf3dfe3e5e1e79fd3edf9eff1f0f3cfe9f5f9fd3e5f6fcf8f7f879e7fafdbf3dfe3e1e79fd3ebf6eff3cfe9f5fafd3e79f6e8fb7e7bfc7cfc33fa6c12441f5cfb747cfe9f2fb7d3b7f7e9e3f6fcf7f8f97879e7f4fb7e7bfc7c3cf3fa7d7e7f4f97dbf3e3dfe1e79febf6fcf7f8f879e7f4fafdbbfcf3fa7d7ebf4f9e7dba3edf9eff1f3f0cfe9b049107d73edd1f3fa7cbedf4edfdfa78fdbf3dfe3e5e1e79fd3edf9eff1f0f3cfe9f5f9fd3e5f6fcf8f7f879e7fafdbf3dfe3e1e79fd3ebf6eff3cfe9f5fafd3e79f6e8fb7e7bfc7cfc33fa6c12441fbfdfeff7fbfdfeff7fbfdfeff7fbfdfeff7fbfdfeff7fbfdfeff7fbfdfeff7fbfdfeff7fbfdfeff7fbfdfeff7fbfdfeff7fbfdfeff7fbfdfeff7fbfdfeff7fbfdfeff7fbfdfeff7fbfdfeff7fbfdfeff624880d6a7a664d4b9d1100761b92f0c58dba71',
   'foo=ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ\
 ZZZZZZZZZZZZZZZZZZZZZZZZZZLASDJKHQKBZXOQWEOPIUAXQWEOIUAXLJKHQWOEIUAL\
 QWEOIUAXLQEUAXLLKJASDQWEOUIAXN1234LASDJKHQKBZXOQWEOPIUAXQWEOIUAXLJKH\
@@ -87,122 +72,235 @@ QWOEIUALQWEOIUAXLQEUAXLLKJASDQWEOUIAXN1234LASDJKHQKBZXOQWEOPIUAXQWEO\
 IUAXLJKHQWOEIUALQWEOIUAXLQEUAXLLKJASDQWEOUIAXN1234LASDJKHQKBZXOQWEOP\
 IUAXQWEOIUAXLJKHQWOEIUALQWEOIUAXLQEUAXLLKJASDQWEOUIAXN1234AAAAAAAAAA\
 AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA1234 m\
-ax-age=3600; version=1': 'c5adb7fcff3fcff3fcff3fcff3fcff3fcff3fcff3f\
-cff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff\
-3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fcff3fc\
-ff3fcff3e5bfc3b7e3fdfbfedfdf5ff9fbfa7dbf5ddf4fafc3f1bff7f6fd777d3e1f\
-8dffbf97c7fbf7fdbf5f4eef87e37fcbedfaeefa7c3f1bff7f2fb777e37fefe5f2fe\
-fe3bfc3b7edfaeefa7e3e1bff7f331e69fe5bfc3b7e3fdfbfedfdf5ff9fbfa7dbf5d\
-df4fafc3f1bff7f6fd777d3e1f8dffbf97c7fbf7fdbf5f4eef87e37fcbedfaeefa7c\
-3f1bff7f2fb777e37fefe5f2fefe3bfc3b7edfaeefa7e3e1bff7f331e69fe5bfc3b7\
-e3fdfbfedfdf5ff9fbfa7dbf5ddf4fafc3f1bff7f6fd777d3e1f8dffbf97c7fbf7fd\
-bf5f4eef87e37fcbedfaeefa7c3f1bff7f2fb777e37fefe5f2fefe3bfc3b7edfaeef\
-a7e3e1bff7f331e69fe5bfc3b7e3fdfbfedfdf5ff9fbfa7dbf5ddf4fafc3f1bff7f6\
-fd777d3e1f8dffbf97c7fbf7fdbf5f4eef87e37fcbedfaeefa7c3f1bff7f2fb777e3\
-7fefe5f2fefe3bfc3b7edfaeefa7e3e1bff7f331e69f7efdfbf7efdfbf7efdfbf7ef\
-dfbf7efdfbf7efdfbf7efdfbf7efdfbf7efdfbf7efdfbf7efdfbf7efdfbf7efdfbf7\
-efdfbf7efdfbf7efdfbf7efdfbf7efdfbcc79a7e8d11e72a321b66a4a5eae8e62f82\
-9acb4d'
+ax-age=3600; version=1': 'e0d6cffbfdfeff7fbfdfeff7fbfdfeff7fbfdfeff7fbfdfeff7fbfdfeff7fbfdfeff7fbfdfeff7fbfdfeff7fbfdfeff7fbfdfeff7fbfdfeff7fbfdfeff7fbfdfeff7fbfdfeff7fbfdfeff7fbfdfeff7fbfdfeff7f5cfb747cfe9f2fb7d3b7f7e9e3f6fcf7f8f97879e7f4fb7e7bfc7c3cf3fa7d7e7f4f97dbf3e3dfe1e79febf6fcf7f8f879e7f4fafdbbfcf3fa7d7ebf4f9e7dba3edf9eff1f3f0cfe9b049107d73edd1f3fa7cbedf4edfdfa78fdbf3dfe3e5e1e79fd3edf9eff1f0f3cfe9f5f9fd3e5f6fcf8f7f879e7fafdbf3dfe3e1e79fd3ebf6eff3cfe9f5fafd3e79f6e8fb7e7bfc7cfc33fa6c12441f5cfb747cfe9f2fb7d3b7f7e9e3f6fcf7f8f97879e7f4fb7e7bfc7c3cf3fa7d7e7f4f97dbf3e3dfe1e79febf6fcf7f8f879e7f4fafdbbfcf3fa7d7ebf4f9e7dba3edf9eff1f3f0cfe9b049107d73edd1f3fa7cbedf4edfdfa78fdbf3dfe3e5e1e79fd3edf9eff1f0f3cfe9f5f9fd3e5f6fcf8f7f879e7fafdbf3dfe3e1e79fd3ebf6eff3cfe9f5fafd3e79f6e8fb7e7bfc7cfc33fa6c124419f3e7cf9f3e7cf9f3e7cf9f3e7cf9f3e7cf9f3e7cf9f3e7cf9f3e7cf9f3e7cf9f3e7cf9f3e7cf9f3e7cf9f3e7cf9f3e7cf9f3e7cf9f3e7cf9f3e7cf9f3e7ce24880d6a7a664d4b9d1100761b92f0c58dba71'
 };
 
 var test_headers = [{
+  // literal w/index, name index
   header: {
     name: 1,
     value: 'GET',
-    index: true
+    index: true,
+    mustNeverIndex: false,
+    contextUpdate: false,
+    clearReferenceSet: false,
+    newMaxSize: 0
   },
-  buffer: new Buffer('02' + '03474554', 'hex')
+  buffer: new Buffer('42' + '03474554', 'hex')
 }, {
+  // literal w/index, name index
   header: {
     name: 6,
     value: 'http',
-    index: true
+    index: true,
+    mustNeverIndex: false,
+    contextUpdate: false,
+    clearReferenceSet: false,
+    newMaxSize: 0
   },
-  buffer: new Buffer('07' + '83ce3177', 'hex')
+  buffer: new Buffer('47' + '83ADCEBF', 'hex')
 }, {
+  // literal w/index, name index
   header: {
     name: 5,
     value: '/',
-    index: true
+    index: true,
+    mustNeverIndex: false,
+    contextUpdate: false,
+    clearReferenceSet: false,
+    newMaxSize: 0
   },
-  buffer: new Buffer('06' + '012f', 'hex')
+  buffer: new Buffer('46' + '012F', 'hex')
 }, {
+  // literal w/index, name index
   header: {
     name: 3,
     value: 'www.foo.com',
-    index: true
+    index: true,
+    mustNeverIndex: false,
+    contextUpdate: false,
+    clearReferenceSet: false,
+    newMaxSize: 0
   },
-  buffer: new Buffer('04' + '88db6d898b5a44b74f', 'hex')
+  buffer: new Buffer('44' + '89E7CF9BFC1AD7D4DB7F', 'hex')
 }, {
+  // literal w/index, name index
   header: {
     name: 2,
     value: 'https',
-    index: true
+    index: true,
+    mustNeverIndex: false,
+    contextUpdate: false,
+    clearReferenceSet: false,
+    newMaxSize: 0
   },
-  buffer: new Buffer('03' + '84ce31743f', 'hex')
+  buffer: new Buffer('43' + '84ADCEBF1F', 'hex')
 }, {
+  // literal w/index, name index
   header: {
     name: 1,
     value: 'www.bar.com',
-    index: true
+    index: true,
+    mustNeverIndex: false,
+    contextUpdate: false,
+    clearReferenceSet: false,
+    newMaxSize: 0
   },
-  buffer: new Buffer('02' + '88db6d897a1e44b74f', 'hex')
+  buffer: new Buffer('42' + '89E7CF9BFBD383EA6DBF', 'hex')
 }, {
+  // literal w/index, name index
   header: {
-    name: 28,
+    name: 29,
     value: 'no-cache',
-    index: true
+    index: true,
+    mustNeverIndex: false,
+    contextUpdate: false,
+    clearReferenceSet: false,
+    newMaxSize: 0
   },
-  buffer: new Buffer('1d' + '8663654a1398ff', 'hex')
+  buffer: new Buffer('5e' + '86B9B9949556BF', 'hex')
 }, {
+  // indexed
   header: {
     name: 3,
     value: 3,
-    index: false
+    index: false,
+    mustNeverIndex: false,
+    contextUpdate: false,
+    clearReferenceSet: false,
+    newMaxSize: 0
   },
   buffer: new Buffer('84', 'hex')
 }, {
+  // indexed
   header: {
     name: 5,
     value: 5,
-    index: false
+    index: false,
+    mustNeverIndex: false,
+    contextUpdate: false,
+    clearReferenceSet: false,
+    newMaxSize: 0
   },
   buffer: new Buffer('86', 'hex')
 }, {
+  // literal w/index, name index
   header: {
     name: 4,
     value: '/custom-path.css',
-    index: true
+    index: true,
+    mustNeverIndex: false,
+    contextUpdate: false,
+    clearReferenceSet: false,
+    newMaxSize: 0
   },
-  buffer: new Buffer('05' + '8b04eb08b7495c88e644c21f', 'hex')
+  buffer: new Buffer('45' + '8C3AB8E2E6DB9AF4BAB7D58E3F', 'hex')
 }, {
+  // literal w/index, new name & value
   header: {
     name: 'custom-key',
     value: 'custom-value',
-    index: true
+    index: true,
+    mustNeverIndex: false,
+    contextUpdate: false,
+    clearReferenceSet: false,
+    newMaxSize: 0
   },
-  buffer: new Buffer('00' + '884eb08b749790fa7f' + '894eb08b74979a17a8ff', 'hex')
+  buffer: new Buffer('40' + '88571C5CDB737B2FAF' + '89571C5CDB73724D9C57', 'hex')
 }, {
+  // indexed
   header: {
     name: 2,
     value: 2,
-    index: false
+    index: false,
+    mustNeverIndex: false,
+    contextUpdate: false,
+    clearReferenceSet: false,
+    newMaxSize: 0
   },
   buffer: new Buffer('83', 'hex')
 }, {
+  // indexed
   header: {
     name: 6,
     value: 6,
-    index: false
+    index: false,
+    mustNeverIndex: false,
+    contextUpdate: false,
+    clearReferenceSet: false,
+    newMaxSize: 0
   },
   buffer: new Buffer('87', 'hex')
+}, {
+  // Literal w/o index, name index
+  header: {
+    name: 6,
+    value: "whatever",
+    index: false,
+    mustNeverIndex: false,
+    contextUpdate: false,
+    clearReferenceSet: false,
+    newMaxSize: 0
+  },
+  buffer: new Buffer('07' + '86E75A5CBE4BC3', 'hex')
+}, {
+  // Literal w/o index, new name & value
+  header: {
+    name: "foo",
+    value: "bar",
+    index: false,
+    mustNeverIndex: false,
+    contextUpdate: false,
+    clearReferenceSet: false,
+    newMaxSize: 0
+  },
+  buffer: new Buffer('00' + '03666F6F' + '03626172', 'hex')
+}, {
+  // Literal never indexed, name index
+  header: {
+    name: 6,
+    value: "whatever",
+    index: false,
+    mustNeverIndex: true,
+    contextUpdate: false,
+    clearReferenceSet: false,
+    newMaxSize: 0
+  },
+  buffer: new Buffer('17' + '86E75A5CBE4BC3', 'hex')
+}, {
+  // Literal never indexed, new name & value
+  header: {
+    name: "foo",
+    value: "bar",
+    index: false,
+    mustNeverIndex: true,
+    contextUpdate: false,
+    clearReferenceSet: false,
+    newMaxSize: 0
+  },
+  buffer: new Buffer('10' + '03666F6F' + '03626172', 'hex')
 }, {
   header: {
     name: -1,
     value: -1,
-    index: true
+    index: false,
+    mustNeverIndex: false,
+    contextUpdate: true,
+    clearReferenceSet: true,
+    newMaxSize: 0
   },
-  buffer: new Buffer('8080', 'hex')
+  buffer: new Buffer('30', 'hex')
+}, {
+  header: {
+    name: -1,
+    value: -1,
+    index: false,
+    mustNeverIndex: false,
+    contextUpdate: true,
+    clearReferenceSet: false,
+    newMaxSize: 100
+  },
+  buffer: new Buffer('2F55', 'hex')
 }];
 
 var test_header_sets = [{
@@ -240,9 +338,6 @@ var test_header_sets = [{
     'custom-key': 'custom-value'
   },
   buffer: test_headers[3].buffer
-}, {
-  headers: {},
-  buffer: test_headers[13].buffer
 }, {
   headers: {
     ':status': '200',
@@ -356,7 +451,7 @@ describe('compressor.js', function() {
     describe('method decompress(buffer)', function() {
       it('should return the parsed header set in { name1: value1, name2: [value2, value3], ... } format', function() {
         var decompressor = new Decompressor(util.log, 'REQUEST');
-        for (var i = 0; i < 5; i++) {
+        for (var i = 0; i < test_header_sets.length - 1; i++) {
           var header_set = test_header_sets[i];
           expect(decompressor.decompress(header_set.buffer)).to.deep.equal(header_set.headers);
         }


### PR DESCRIPTION
Here's the protocol-level implementation of draft11. All tests pass, new tests have been added where appropriate.

The one major change I didn't do is actually implementing the priority scheme on the connection (in other words, actually prioritizing streams). I felt that was an OK tradeoff to make, since the new prioritization scheme is still in flux, and all priorities are advisory, anyway :) Once we get prioritization more locked-in in the spec, I'll fix up the implementation of prioritization. Right now, this just means that all streams will have the same priority (or one less, for pushed streams).

I'll also be sending a PR to node-http2 to update the version of the protocol library used.
