### PR TITLE
Implement ability to send ALTSVC frames

### DIFF
--- a/lib/stream.js
+++ b/lib/stream.js
@@ -153,6 +153,26 @@ Stream.prototype.reset = function reset(error) {
   }
 };
 
+// Specify an alternate service for the origin of this stream
+Stream.prototype.altsvc = function altsvc(host, port, protocolID, maxAge, origin) {
+    var stream;
+    if (origin) {
+        stream = 0;
+    } else {
+        stream = this.id;
+    }
+    this._pushUpstream({
+        type: 'ALTSVC',
+        flags: {},
+        stream: stream,
+        host: host,
+        port: port,
+        protocolID: protocolID,
+        origin: origin,
+        maxAge: maxAge
+    });
+};
+
 // Data flow
 // ---------
 


### PR DESCRIPTION
I needed the ability to test ALTSVC frames for some stuff we're preparing for NYC, so I went ahead and implemented it in node-http2. This is the bit that actually sends an ALTSVC frame. The plumbing comes in a pull request for node-http2
