### PR TITLE
Fix header ordering

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,10 @@
 Version history
 ===============
 
+### 0.14.1 (2014-08-01) ###
+
+* Fixed an error that caused us to send :-headers after non-:-headers
+
 ### 0.14.0 (2014-07-31) ###
 
 * Upgrade to the latest draft: [draft-ietf-httpbis-http2-14][draft-14]

--- a/lib/compressor.js
+++ b/lib/compressor.js
@@ -1103,7 +1103,19 @@ Compressor.prototype.setTableSizeLimit = function setTableSizeLimit(size) {
 // but the API becomes simpler.
 Compressor.prototype.compress = function compress(headers) {
   var compressor = new HeaderSetCompressor(this._log, this._table);
+  var colonHeaders = [];
+  var nonColonHeaders = [];
+
+  // To ensure we send colon headers first
   for (var name in headers) {
+      if (name.trim()[0] === ':') {
+          colonHeaders.push(name);
+      } else {
+          nonColonHeaders.push(name);
+      }
+  }
+
+  function compressHeader(name) {
     var value = headers[name];
     name = String(name).toLowerCase();
 
@@ -1126,6 +1138,14 @@ Compressor.prototype.compress = function compress(headers) {
       compressor.write([name, String(value)]);
     }
   }
+
+  for (var idx = 0; idx < colonHeaders.length; idx++) {
+      compressHeader(colonHeaders[idx]);
+  }
+  for (var idx = 0; idx < nonColonHeaders.length; idx++) {
+      compressHeader(nonColonHeaders[idx]);
+  }
+
   compressor.end();
 
   var chunk, chunks = [];
@@ -1213,11 +1233,18 @@ Decompressor.prototype.decompress = function decompress(block) {
   var decompressor = new HeaderSetDecompressor(this._log, this._table);
   decompressor.end(block);
 
+  var seenNonColonHeader = false;
   var headers = {};
   var pair;
   while (pair = decompressor.read()) {
     var name = pair[0];
     var value = pair[1];
+    var isColonHeader = (name.trim()[0] === ':');
+    if (seenNonColonHeader && isColonHeader) {
+        this.emit('error', 'PROTOCOL_ERROR');
+        return headers;
+    }
+    seenNonColonHeader = !isColonHeader;
     if (name in headers) {
       if (headers[name] instanceof Array) {
         headers[name].push(value);

--- a/lib/compressor.js
+++ b/lib/compressor.js
@@ -1108,11 +1108,11 @@ Compressor.prototype.compress = function compress(headers) {
 
   // To ensure we send colon headers first
   for (var name in headers) {
-      if (name.trim()[0] === ':') {
-          colonHeaders.push(name);
-      } else {
-          nonColonHeaders.push(name);
-      }
+    if (name.trim()[0] === ':') {
+      colonHeaders.push(name);
+    } else {
+      nonColonHeaders.push(name);
+    }
   }
 
   function compressHeader(name) {
@@ -1140,10 +1140,10 @@ Compressor.prototype.compress = function compress(headers) {
   }
 
   for (var idx = 0; idx < colonHeaders.length; idx++) {
-      compressHeader(colonHeaders[idx]);
+    compressHeader(colonHeaders[idx]);
   }
   for (var idx = 0; idx < nonColonHeaders.length; idx++) {
-      compressHeader(nonColonHeaders[idx]);
+    compressHeader(nonColonHeaders[idx]);
   }
 
   compressor.end();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http2-protocol",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "A JavaScript implementation of the HTTP/2 framing layer",
   "main": "lib/index.js",
   "engines" : {


### PR DESCRIPTION
So I totally failed to properly order colon-headers before non-colon-headers (I had done that in firefox, too, both will now be updated). I'll merge this, then update node-http2 to require protocol 0.14.1, so everyone can get the new hotness.
